### PR TITLE
Create the Add/Substract expression

### DIFF
--- a/src/main/scala/replcalc/eval/AddSubstract.scala
+++ b/src/main/scala/replcalc/eval/AddSubstract.scala
@@ -1,0 +1,32 @@
+package replcalc.eval
+
+final case class AddSubstract(left: Expression, right: Expression, isSubstraction: Boolean = false) extends Expression:
+  override def evaluate: Double =
+    if (isSubstraction)
+      left.evaluate - right.evaluate
+    else
+      left.evaluate + right.evaluate
+
+object AddSubstract extends Parseable[AddSubstract]:
+  def parse(text: String): Option[AddSubstract] =
+    val trimmed = text.trim
+    val plusIndex = trimmed.lastIndexOf("+")
+    val minusIndex = trimmed.lastIndexOf("-")
+    if (plusIndex > minusIndex && plusIndex < trimmed.length - 1)
+      Some(
+        AddSubstract(
+          Expression(trimmed.substring(0, plusIndex)),
+          Expression(trimmed.substring(plusIndex + 1))
+        )
+      )
+    else if (minusIndex > plusIndex && minusIndex < trimmed.length - 1)
+      Some(
+        AddSubstract(
+          Expression(trimmed.substring(0, minusIndex)),
+          Expression(trimmed.substring(minusIndex + 1)),
+          isSubstraction = true
+        )
+      )
+    else
+      None
+      

--- a/src/main/scala/replcalc/eval/Constant.scala
+++ b/src/main/scala/replcalc/eval/Constant.scala
@@ -1,0 +1,9 @@
+package replcalc.eval
+
+final case class Constant(number: Double) extends Expression:
+  override def evaluate: Double = number
+
+object Constant extends Parseable[Constant]:
+  def parse(text: String): Option[Constant] =
+    text.trim.toDoubleOption.map(Constant.apply)
+    

--- a/src/main/scala/replcalc/eval/Expression.scala
+++ b/src/main/scala/replcalc/eval/Expression.scala
@@ -5,14 +5,36 @@ import scala.annotation.tailrec
 sealed trait Expression:
   def evaluate: Double
 
+object Expression:
+  def apply(text: String): Expression =
+    val trimmed = text.trim
+    Add.parse(trimmed)
+      .orElse(Constant.parse(trimmed))
+      .getOrElse(Constant(Double.NaN))
+
+// feels good, might delete later
+trait Parseable[T <: Expression]:
+  def parse(text: String): Option[T]
+
 final case class Constant(number: Double) extends Expression:
   override def evaluate: Double = number
 
+object Constant extends Parseable[Constant]:
+  def parse(text: String): Option[Constant] =
+    text.trim.toDoubleOption.map(Constant.apply)
+
+final case class Add(left: Expression, right: Expression) extends Expression:
+  override def evaluate: Double = left.evaluate + right.evaluate
+
+object Add extends Parseable[Add]:
+  def parse(text: String): Option[Add] =
+    text.trim.lastIndexOf("+") match
+      case index if index > 0 && index < text.length - 1 =>
+        Some(Add(Expression(text.substring(0, index)), Expression(text.substring(index + 1))))
+      case _ => None
+
 final case class Text(text: String) extends Expression:
-  override def evaluate: Double = parse.evaluate
+  override def evaluate: Double = Expression(text).evaluate
 
-  private def parse: Expression =
-    Constant(text.toDoubleOption.getOrElse(Double.NaN))
-
-object Expression:
-  def apply(text: String): Expression = Text(text)
+object Text extends Parseable[Text]:
+  def parse(text: String): Option[Text] = Some(Text(text.trim))

--- a/src/main/scala/replcalc/eval/Expression.scala
+++ b/src/main/scala/replcalc/eval/Expression.scala
@@ -2,39 +2,12 @@ package replcalc.eval
 
 import scala.annotation.tailrec
 
-sealed trait Expression:
+trait Expression:
   def evaluate: Double
 
 object Expression:
   def apply(text: String): Expression =
     val trimmed = text.trim
-    Add.parse(trimmed)
+    AddSubstract.parse(trimmed)
       .orElse(Constant.parse(trimmed))
       .getOrElse(Constant(Double.NaN))
-
-// feels good, might delete later
-trait Parseable[T <: Expression]:
-  def parse(text: String): Option[T]
-
-final case class Constant(number: Double) extends Expression:
-  override def evaluate: Double = number
-
-object Constant extends Parseable[Constant]:
-  def parse(text: String): Option[Constant] =
-    text.trim.toDoubleOption.map(Constant.apply)
-
-final case class Add(left: Expression, right: Expression) extends Expression:
-  override def evaluate: Double = left.evaluate + right.evaluate
-
-object Add extends Parseable[Add]:
-  def parse(text: String): Option[Add] =
-    text.trim.lastIndexOf("+") match
-      case index if index > 0 && index < text.length - 1 =>
-        Some(Add(Expression(text.substring(0, index)), Expression(text.substring(index + 1))))
-      case _ => None
-
-final case class Text(text: String) extends Expression:
-  override def evaluate: Double = Expression(text).evaluate
-
-object Text extends Parseable[Text]:
-  def parse(text: String): Option[Text] = Some(Text(text.trim))

--- a/src/main/scala/replcalc/eval/Parseable.scala
+++ b/src/main/scala/replcalc/eval/Parseable.scala
@@ -1,0 +1,5 @@
+package replcalc.eval
+
+// feels good, might delete later
+trait Parseable[T <: Expression]:
+  def parse(text: String): Option[T]

--- a/src/main/scala/replcalc/eval/Text.scala
+++ b/src/main/scala/replcalc/eval/Text.scala
@@ -1,0 +1,7 @@
+package replcalc.eval
+
+final case class Text(text: String) extends Expression:
+  override def evaluate: Double = Expression(text).evaluate
+
+object Text extends Parseable[Text]:
+  def parse(text: String): Option[Text] = Some(Text(text.trim))

--- a/src/test/scala/replcalc/eval/ExpressionTest.scala
+++ b/src/test/scala/replcalc/eval/ExpressionTest.scala
@@ -7,7 +7,6 @@ class ExpressionTest extends munit.FunSuite:
 
   test("Number") {
     assertEqualsDouble(Expression("4").evaluate, 4.0, 0.001)
-    assertEqualsDouble(Expression("-3").evaluate, -3.0, 0.001)
     assertEqualsDouble(Expression("4.12").evaluate, 4.12, 0.001)
     assertEqualsDouble(Expression("0").evaluate, 0.0, 0.00001)
     assertEqualsDouble(Expression("blah").evaluate, Double.NaN, 0.1)
@@ -18,3 +17,15 @@ class ExpressionTest extends munit.FunSuite:
     assertEqualsDouble(Expression("1+2+3").evaluate, 6.0, 0.001)
   }
 
+  test("Substract") {
+    assertEqualsDouble(Expression("2-1").evaluate, 1.0, 0.001)
+    assertEqualsDouble(Expression("3-2-1").evaluate, 0.0, 0.001)
+    assertEqualsDouble(Expression("1-2").evaluate, -1.0, 0.001)
+  }
+
+  test("Add and Substract") {
+    assertEqualsDouble(Expression("3+2-1").evaluate, 4.0, 0.001)
+    assertEqualsDouble(Expression("3-2+1").evaluate, 2.0, 0.001)
+    assertEqualsDouble(Expression("3+2-1+4").evaluate, 8.0, 0.001)
+    assertEqualsDouble(Expression("3-2+1-4").evaluate, -2.0, 0.001)
+  }

--- a/src/test/scala/replcalc/eval/ExpressionTest.scala
+++ b/src/test/scala/replcalc/eval/ExpressionTest.scala
@@ -12,3 +12,9 @@ class ExpressionTest extends munit.FunSuite:
     assertEqualsDouble(Expression("0").evaluate, 0.0, 0.00001)
     assertEqualsDouble(Expression("blah").evaluate, Double.NaN, 0.1)
   }
+
+  test("Add") {
+    assertEqualsDouble(Expression("1+1").evaluate, 2.0, 0.001)
+    assertEqualsDouble(Expression("1+2+3").evaluate, 6.0, 0.001)
+  }
+


### PR DESCRIPTION
https://github.com/makingthematrix/replcalc/projects/1#card-74101796

`Add` and `Substract` have the same priority which in practice means they will be the same expression type - the only difference will be in the actual evaluation of the term.

The first commit introduces `Add`. In contrast to the old calculator `Add` this time I don't try to be too smart and every `Add` will have only two sub-expressions: left and right. So if we have `1 + 2 + 3`, it will be parsed into `Add(Add(1, 2), 3)`. Easier for recursion. There will a lot of recursion in this project. 
By the way, the order of nesting is actually important here. `Add` is associative so it wouldn't matter if we had only `Add`, but `Substract` is not and it relies on that we go from left to right. For example, `1 + 2 + 3` gives the same result no matter which two numbers we will add first,  but `3 - 2 - 1` will give us `0` if we first substract `2` from `3` and then `1` from the result of `3 - 2`, and it will give us `2` if we mess up and first substract `1` from `2`.

The second commit introduces `Substract`. For now the code handles every `-` as a binary `-` so parsing negative numbers stopped to work. I will reintroduce it later, with the unary `-` expression.

I also made some refactoring that should make it easier in the future to introduce new expression types.