### PR TITLE
feat: Create the Multiply/Divide expression

### DIFF
--- a/src/main/scala/replcalc/eval/Expression.scala
+++ b/src/main/scala/replcalc/eval/Expression.scala
@@ -9,5 +9,6 @@ object Expression:
   def apply(text: String): Expression =
     val trimmed = text.trim
     AddSubstract.parse(trimmed)
+      .orElse(MultiplyDivide.parse(trimmed))
       .orElse(Constant.parse(trimmed))
       .getOrElse(Constant(Double.NaN))

--- a/src/main/scala/replcalc/eval/MultiplyDivide.scala
+++ b/src/main/scala/replcalc/eval/MultiplyDivide.scala
@@ -1,0 +1,32 @@
+package replcalc.eval
+
+final case class MultiplyDivide(left: Expression, right: Expression, isDivision: Boolean = false) extends Expression:
+  override def evaluate: Double =
+    if (isDivision)
+      left.evaluate / right.evaluate
+    else
+      left.evaluate * right.evaluate
+
+object MultiplyDivide extends Parseable[MultiplyDivide]:
+  def parse(text: String): Option[MultiplyDivide] =
+    val trimmed = text.trim
+    val mulIndex = trimmed.lastIndexOf("*")
+    val divIndex = trimmed.lastIndexOf("/")
+    if (mulIndex > divIndex && mulIndex < trimmed.length - 1)
+      Some(
+        MultiplyDivide(
+          Expression(trimmed.substring(0, mulIndex)),
+          Expression(trimmed.substring(mulIndex + 1))
+        )
+      )
+    else if (divIndex > mulIndex && divIndex < trimmed.length - 1)
+      Some(
+        MultiplyDivide(
+          Expression(trimmed.substring(0, divIndex)),
+          Expression(trimmed.substring(divIndex + 1)),
+          isDivision = true
+        )
+      )
+    else
+      None
+      

--- a/src/test/scala/replcalc/eval/ExpressionTest.scala
+++ b/src/test/scala/replcalc/eval/ExpressionTest.scala
@@ -29,3 +29,30 @@ class ExpressionTest extends munit.FunSuite:
     assertEqualsDouble(Expression("3+2-1+4").evaluate, 8.0, 0.001)
     assertEqualsDouble(Expression("3-2+1-4").evaluate, -2.0, 0.001)
   }
+
+  test("Multiply") {
+    assertEqualsDouble(Expression("1*1").evaluate, 1.0, 0.001)
+    assertEqualsDouble(Expression("1*2*3").evaluate, 6.0, 0.001)
+    assertEqualsDouble(Expression("5.0*2.5").evaluate, 12.5, 0.001)
+    assertEqualsDouble(Expression("3.0*0").evaluate, 0.0, 0.001)
+  }
+
+  test("Divide") {
+    assertEqualsDouble(Expression("2/1").evaluate, 2.0, 0.001)
+    assertEqualsDouble(Expression("3/2/2").evaluate, 0.75, 0.001)
+    assertEqualsDouble(Expression("1.0/2.0").evaluate, 0.5, 0.001)
+  }
+
+  test("Multiply and Divide") {
+    assertEqualsDouble(Expression("3*2/1").evaluate, 6.0, 0.001)
+    assertEqualsDouble(Expression("3/2*1").evaluate, 1.5, 0.001)
+    assertEqualsDouble(Expression("3*2/2*4").evaluate, 12.0, 0.001)
+    assertEqualsDouble(Expression("3/2*2/4").evaluate, 0.75, 0.001)
+  }
+
+  test("Add and Substract and Multiply and Divide") {
+    assertEqualsDouble(Expression("1+3*2/1").evaluate, 7.0, 0.001)
+    assertEqualsDouble(Expression("3/2*1+1").evaluate, 2.5, 0.001)
+    assertEqualsDouble(Expression("0-3*2/2*4").evaluate, -12.0, 0.001)
+    assertEqualsDouble(Expression("3/2+2/4-3*0.5").evaluate, 0.5, 0.001)
+  }


### PR DESCRIPTION
https://github.com/makingthematrix/replcalc/projects/1#card-74101803

I decided to write this together in one commit because it's basically a logical copy of the previous chunk. The multiply/divide expression is parsed in the same way as the add/substract, we just look for different operators.

One curious thing you may notice is that we say that addition and substraction has *lower* priority than multiplication and division when it comes to the *evaluation* of a complex expression, but while *parsing* this is reverted. We first need to look for `+` and `-`, split the expression along these lines, and only then look for `*` and `/` in the chunks we got. This way we will create our Abstract Syntax Tree. And  then, during *evaluation*, we will go down the tree and start to evaluate it from bottom-up, so *first* we will evaluate multiplication and division, and only then addition and substraction, which we will find higher in the tree.