### PR TITLE
feat: Unary minus

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 8
       uses: actions/setup-java@v2
       with:
-        java-version: '11'
+        java-version: '8'
         distribution: 'adopt'
     - name: Run tests
-      run: sbt test
+      run: sbt clean test

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 8
+    - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
-        java-version: '8'
-        distribution: 'adopt'
+        java-version: '11'
+        distribution: 'liberica'
     - name: Run tests
       run: sbt clean test

--- a/src/main/scala/replcalc/eval/AddSubstract.scala
+++ b/src/main/scala/replcalc/eval/AddSubstract.scala
@@ -1,5 +1,7 @@
 package replcalc.eval
 
+import scala.annotation.tailrec
+
 final case class AddSubstract(left: Expression, right: Expression, isSubstraction: Boolean = false) extends Expression:
   override def evaluate: Double =
     if (isSubstraction)
@@ -11,7 +13,7 @@ object AddSubstract extends Parseable[AddSubstract]:
   def parse(text: String): Option[AddSubstract] =
     val trimmed = text.trim
     val plusIndex = trimmed.lastIndexOf("+")
-    val minusIndex = trimmed.lastIndexOf("-")
+    val minusIndex = lastBinaryMinus(text)
     if (plusIndex > minusIndex && plusIndex < trimmed.length - 1)
       Some(
         AddSubstract(
@@ -29,4 +31,11 @@ object AddSubstract extends Parseable[AddSubstract]:
       )
     else
       None
+
+  @tailrec
+  private def lastBinaryMinus(text: String): Int =
+    val minusIndex = text.lastIndexOf("-")
+    if (minusIndex <= 0) -1
+    else if (!Expression.operators.contains(text.charAt(minusIndex - 1))) minusIndex
+    else lastBinaryMinus(text.substring(0, minusIndex))
       

--- a/src/main/scala/replcalc/eval/Expression.scala
+++ b/src/main/scala/replcalc/eval/Expression.scala
@@ -12,3 +12,5 @@ object Expression:
       .orElse(MultiplyDivide.parse(trimmed))
       .orElse(Constant.parse(trimmed))
       .getOrElse(Constant(Double.NaN))
+  
+  val operators: Set[Char] = Set('+', '-', '*', '/')

--- a/src/main/scala/replcalc/eval/Expression.scala
+++ b/src/main/scala/replcalc/eval/Expression.scala
@@ -10,6 +10,7 @@ object Expression:
     val trimmed = text.trim
     AddSubstract.parse(trimmed)
       .orElse(MultiplyDivide.parse(trimmed))
+      .orElse(UnaryMinus.parse(trimmed))
       .orElse(Constant.parse(trimmed))
       .getOrElse(Constant(Double.NaN))
   

--- a/src/test/scala/replcalc/eval/ExpressionTest.scala
+++ b/src/test/scala/replcalc/eval/ExpressionTest.scala
@@ -62,4 +62,5 @@ class ExpressionTest extends munit.FunSuite:
     assertEqualsDouble(Expression("5*-3").evaluate, -15.0, 0.001)
     assertEqualsDouble(Expression("2+-3").evaluate, -1.0, 0.001)
     assertEqualsDouble(Expression("2--3").evaluate, 5.0, 0.001)
+    assertEqualsDouble(Expression("3/2+2/-4-3*0.5").evaluate, -0.5, 0.001)
   }

--- a/src/test/scala/replcalc/eval/ExpressionTest.scala
+++ b/src/test/scala/replcalc/eval/ExpressionTest.scala
@@ -56,3 +56,10 @@ class ExpressionTest extends munit.FunSuite:
     assertEqualsDouble(Expression("0-3*2/2*4").evaluate, -12.0, 0.001)
     assertEqualsDouble(Expression("3/2+2/4-3*0.5").evaluate, 0.5, 0.001)
   }
+
+  test("Unary minus") {
+    assertEqualsDouble(Expression("-3").evaluate, -3.0, 0.001)
+    assertEqualsDouble(Expression("5*-3").evaluate, -15.0, 0.001)
+    assertEqualsDouble(Expression("2+-3").evaluate, -1.0, 0.001)
+    assertEqualsDouble(Expression("2--3").evaluate, 5.0, 0.001)
+  }


### PR DESCRIPTION
https://github.com/makingthematrix/replcalc/projects/1#card-74101815

The simplest way to implement a unary `-` operator is to skip it while looking for binary `-`. For now the only other place where we can find a unary `-` is in front of numbers, and that means they can be a part of the Constant expression.

To identify and skip them, I changed the way AddSubstract looks for the `-` operator. If there is `-` in the text, the program looks what is in front of it. If it's one of the operators or the `-` operator is at the very beginning of the text, then it's a unary `-` and we need to keep looking, moving one character back, from the end of the text to the front. Otherwise it's a binary one and this is what we look for.

On top of that, there is some refactoring in anticipation of that I will have to manage the unary `-` not only in front of constants (where it is handled automatically) but also before parentheses, values, and functions. They will be modelled
as expressions as well, so the unary `-` needs to be also an expression with one inner expression in it.