### PR TITLE
feat: Display meaningful errors #1 - from NaN to Option

### DIFF
--- a/src/main/scala/replcalc/Main.scala
+++ b/src/main/scala/replcalc/Main.scala
@@ -13,5 +13,7 @@ def main(args: String*): Unit =
     if text.trim == ":exit" then
       exit = true
     else
-      val result = Expression(text).evaluate
-      println(result)
+      Expression.parse(text).flatMap(_.evaluate) match {
+        case Some(result) => println(result)
+        case None         => println("Error: Unable to parse or evaluate")
+      }

--- a/src/main/scala/replcalc/eval/Constant.scala
+++ b/src/main/scala/replcalc/eval/Constant.scala
@@ -1,7 +1,7 @@
 package replcalc.eval
 
 final case class Constant(number: Double) extends Expression:
-  override def evaluate: Double = number
+  override def evaluate: Option[Double] = Some(number)
 
 object Constant extends Parseable[Constant]:
   override def parse(text: String): Option[Constant] =

--- a/src/main/scala/replcalc/eval/Expression.scala
+++ b/src/main/scala/replcalc/eval/Expression.scala
@@ -3,16 +3,15 @@ package replcalc.eval
 import scala.annotation.tailrec
 
 trait Expression:
-  def evaluate: Double
+  def evaluate: Option[Double]
 
-object Expression:
-  def apply(text: String): Expression =
+object Expression extends Parseable[Expression]:
+  def parse(text: String): Option[Expression] =
     val trimmed = text.trim
     AddSubstract.parse(trimmed)
       .orElse(MultiplyDivide.parse(trimmed))
       .orElse(UnaryMinus.parse(trimmed))
       .orElse(Constant.parse(trimmed))
-      .getOrElse(Constant(Double.NaN))
   
   val operators: Set[Char] = Set('+', '-', '*', '/')
   

--- a/src/main/scala/replcalc/eval/MultiplyDivide.scala
+++ b/src/main/scala/replcalc/eval/MultiplyDivide.scala
@@ -1,11 +1,12 @@
 package replcalc.eval
 
 final case class MultiplyDivide(left: Expression, right: Expression, isDivision: Boolean = false) extends Expression:
-  override def evaluate: Double =
-    if isDivision then
-      left.evaluate / right.evaluate
-    else
-      left.evaluate * right.evaluate
+  override def evaluate: Option[Double] =
+    for {
+      l <- left.evaluate
+      r <- right.evaluate
+    } yield
+      if isDivision then l / r else l * r
 
 object MultiplyDivide extends Parseable[MultiplyDivide]:
   override def parse(text: String): Option[MultiplyDivide] =
@@ -14,12 +15,10 @@ object MultiplyDivide extends Parseable[MultiplyDivide]:
     val divIndex = trimmed.lastIndexOf("/")
     val (index, isDivision) = if mulIndex > divIndex then (mulIndex, false) else (divIndex, true)
     if index > 0 && index < trimmed.length - 1 then
-      Some(
-        MultiplyDivide(
-          Expression(trimmed.substring(0, index)),
-          Expression(trimmed.substring(index + 1)),
-          isDivision = isDivision
-        )
-      )
+      for {
+        left  <- Expression.parse(trimmed.substring(0, index))
+        right <- Expression.parse(trimmed.substring(index + 1))
+      } yield
+        MultiplyDivide(left, right, isDivision)
     else
       None

--- a/src/main/scala/replcalc/eval/Text.scala
+++ b/src/main/scala/replcalc/eval/Text.scala
@@ -1,7 +1,8 @@
 package replcalc.eval
 
 final case class Text(text: String) extends Expression:
-  override def evaluate: Double = Expression(text).evaluate
+  override def evaluate: Option[Double] =
+    Expression.parse(text).flatMap(_.evaluate)
 
 object Text extends Parseable[Text]:
   override def parse(text: String): Option[Text] = Some(Text(text.trim))

--- a/src/main/scala/replcalc/eval/UnaryMinus.scala
+++ b/src/main/scala/replcalc/eval/UnaryMinus.scala
@@ -1,12 +1,12 @@
 package replcalc.eval
 
 final case class UnaryMinus(innerExpr: Expression) extends Expression:
-  override def evaluate: Double = -innerExpr.evaluate
+  override def evaluate: Option[Double] = innerExpr.evaluate.map(-_)
   
 object UnaryMinus extends Parseable[UnaryMinus]:
   override def parse(text: String): Option[UnaryMinus] =
     val trimmed = text.trim
     if trimmed.length > 1 && trimmed.charAt(0) == '-' then
-      Some(UnaryMinus(Expression(trimmed.substring(1))))
+      Expression.parse(trimmed.substring(1)).map(UnaryMinus.apply)
     else 
       None

--- a/src/test/scala/replcalc/eval/ExpressionTest.scala
+++ b/src/test/scala/replcalc/eval/ExpressionTest.scala
@@ -1,67 +1,72 @@
 package replcalc.eval
 
-import munit.Location
+import munit.{ComparisonFailException, Location}
 
 class ExpressionTest extends munit.FunSuite:
   implicit val location: Location = Location.empty
 
+  private def eval(text: String, expected: Double, delta: Double = 0.001) =
+    Expression.parse(text).flatMap(_.evaluate) match
+      case Some(result) => assertEqualsDouble(result, expected, delta)
+      case None         => failComparison("Unable to parse or evaluate", text, expected)
+
   test("Number") {
-    assertEqualsDouble(Expression("4").evaluate, 4.0, 0.001)
-    assertEqualsDouble(Expression("4.12").evaluate, 4.12, 0.001)
-    assertEqualsDouble(Expression("0").evaluate, 0.0, 0.00001)
-    assertEqualsDouble(Expression("blah").evaluate, Double.NaN, 0.1)
+    eval("4", 4.0)
+    eval("4.12", 4.12)
+    eval("0", 0.0, 0.00001)
+    intercept[ComparisonFailException](eval("blah", Double.NaN))
   }
 
   test("Add") {
-    assertEqualsDouble(Expression("1+1").evaluate, 2.0, 0.001)
-    assertEqualsDouble(Expression("1+2+3").evaluate, 6.0, 0.001)
+    eval("1+1", 2.0)
+    eval("1+2+3", 6.0)
   }
 
   test("Substract") {
-    assertEqualsDouble(Expression("2-1").evaluate, 1.0, 0.001)
-    assertEqualsDouble(Expression("3-2-1").evaluate, 0.0, 0.001)
-    assertEqualsDouble(Expression("1-2").evaluate, -1.0, 0.001)
+    eval("2-1", 1.0)
+    eval("3-2-1", 0.0)
+    eval("1-2", -1.0)
   }
 
   test("Add and Substract") {
-    assertEqualsDouble(Expression("3+2-1").evaluate, 4.0, 0.001)
-    assertEqualsDouble(Expression("3-2+1").evaluate, 2.0, 0.001)
-    assertEqualsDouble(Expression("3+2-1+4").evaluate, 8.0, 0.001)
-    assertEqualsDouble(Expression("3-2+1-4").evaluate, -2.0, 0.001)
+    eval("3+2-1", 4.0)
+    eval("3-2+1", 2.0)
+    eval("3+2-1+4", 8.0)
+    eval("3-2+1-4", -2.0)
   }
 
   test("Multiply") {
-    assertEqualsDouble(Expression("1*1").evaluate, 1.0, 0.001)
-    assertEqualsDouble(Expression("1*2*3").evaluate, 6.0, 0.001)
-    assertEqualsDouble(Expression("5.0*2.5").evaluate, 12.5, 0.001)
-    assertEqualsDouble(Expression("3.0*0").evaluate, 0.0, 0.001)
+    eval("1*1", 1.0)
+    eval("1*2*3", 6.0)
+    eval("5.0*2.5", 12.5)
+    eval("3.0*0", 0.0)
   }
 
   test("Divide") {
-    assertEqualsDouble(Expression("2/1").evaluate, 2.0, 0.001)
-    assertEqualsDouble(Expression("3/2/2").evaluate, 0.75, 0.001)
-    assertEqualsDouble(Expression("1.0/2.0").evaluate, 0.5, 0.001)
+    eval("2/1", 2.0)
+    eval("3/2/2", 0.75)
+    eval("1.0/2.0", 0.5)
   }
 
   test("Multiply and Divide") {
-    assertEqualsDouble(Expression("3*2/1").evaluate, 6.0, 0.001)
-    assertEqualsDouble(Expression("3/2*1").evaluate, 1.5, 0.001)
-    assertEqualsDouble(Expression("3*2/2*4").evaluate, 12.0, 0.001)
-    assertEqualsDouble(Expression("3/2*2/4").evaluate, 0.75, 0.001)
+    eval("3*2/1", 6.0)
+    eval("3/2*1", 1.5)
+    eval("3*2/2*4", 12.0)
+    eval("3/2*2/4", 0.75)
   }
 
   test("Add and Substract and Multiply and Divide") {
-    assertEqualsDouble(Expression("1+3*2/1").evaluate, 7.0, 0.001)
-    assertEqualsDouble(Expression("3/2*1+1").evaluate, 2.5, 0.001)
-    assertEqualsDouble(Expression("0-3*2/2*4").evaluate, -12.0, 0.001)
-    assertEqualsDouble(Expression("3/2+2/4-3*0.5").evaluate, 0.5, 0.001)
+    eval("1+3*2/1", 7.0)
+    eval("3/2*1+1", 2.5)
+    eval("0-3*2/2*4", -12.0)
+    eval("3/2+2/4-3*0.5", 0.5)
   }
 
   test("Unary minus") {
-    assertEqualsDouble(Expression("-3").evaluate, -3.0, 0.001)
-    assertEqualsDouble(Expression("5*-3").evaluate, -15.0, 0.001)
-    assertEqualsDouble(Expression("2+-3").evaluate, -1.0, 0.001)
-    assertEqualsDouble(Expression("2--3").evaluate, 5.0, 0.001)
-    assertEqualsDouble(Expression("3/2+2/-4-3*0.5").evaluate, -0.5, 0.001)
-    assertEqualsDouble(Expression("-").evaluate, Double.NaN, 0.01)
+    eval("-3", -3.0)
+    eval("5*-3", -15.0)
+    eval("2+-3", -1.0)
+    eval("2--3", 5.0)
+    eval("3/2+2/-4-3*0.5", -0.5)
+    intercept[ComparisonFailException](eval("-", Double.NaN))
   }


### PR DESCRIPTION
https://github.com/makingthematrix/replcalc/projects/1#card-74101918

Until now I used `Double.NaN` to indicate that there was an error during parsing or evaluating. In the end, I'd like the REPL to display a meaningful error about what was the problem. There are a few ways to do it and at this point I haven't decided yet, but the first step is already clear: I'm changing the result of evaluation to Option[Double] and so the incorrect evaluation will be represented by `None` instead of `Double.NaN`. If the program fails to evaluate one of the inner expressions, it generates `None` and it should bubble up to the top. In the next commits I will move from `Option[Double]` to a type that is able to also describe the error a bit better. Maybe `Either`, maybe an enum. This refactoring will already make it a bit easier.