### PR TITLE
feat: Display meaningful errors #2 - refactoring

### DIFF
--- a/src/main/scala/replcalc/eval/AddSubstract.scala
+++ b/src/main/scala/replcalc/eval/AddSubstract.scala
@@ -5,10 +5,10 @@ import Expression.isOperator
 
 final case class AddSubstract(left: Expression, right: Expression, isSubstraction: Boolean = false) extends Expression:
   override def evaluate: Option[Double] =
-    for {
+    for 
       l <- left.evaluate
       r <- right.evaluate
-    } yield 
+    yield 
       if isSubstraction then l - r else l + r
 
 object AddSubstract extends Parseable[AddSubstract]:
@@ -18,10 +18,10 @@ object AddSubstract extends Parseable[AddSubstract]:
     val minusIndex = lastBinaryMinus(text)
     val (index, isSubstraction) = if plusIndex > minusIndex then (plusIndex, false) else (minusIndex, true)
     if index > 0 && index < trimmed.length - 1 then
-      for {
+      for 
         left  <- Expression.parse(trimmed.substring(0, index))
         right <- Expression.parse(trimmed.substring(index + 1))
-      } yield 
+      yield 
         AddSubstract(left, right, isSubstraction)
     else
       None

--- a/src/main/scala/replcalc/eval/Expression.scala
+++ b/src/main/scala/replcalc/eval/Expression.scala
@@ -6,13 +6,19 @@ trait Expression:
   def evaluate: Option[Double]
 
 object Expression extends Parseable[Expression]:
-  def parse(text: String): Option[Expression] =
+  override def parse(text: String): Option[Expression] =
     val trimmed = text.trim
-    AddSubstract.parse(trimmed)
-      .orElse(MultiplyDivide.parse(trimmed))
-      .orElse(UnaryMinus.parse(trimmed))
-      .orElse(Constant.parse(trimmed))
-  
-  val operators: Set[Char] = Set('+', '-', '*', '/')
-  
+    object Parsed:
+      def unapply[T <: Expression](stage: String => Option[T]): Option[T] = stage(trimmed)
+    stages.collectFirst { case Parsed(expression) => expression }
+
   inline def isOperator(char: Char): Boolean = operators.contains(char)
+
+  private val operators: Set[Char] = Set('+', '-', '*', '/')
+
+  private val stages = Seq(
+    AddSubstract.parse,
+    MultiplyDivide.parse,
+    UnaryMinus.parse,
+    Constant.parse
+  )

--- a/src/main/scala/replcalc/eval/MultiplyDivide.scala
+++ b/src/main/scala/replcalc/eval/MultiplyDivide.scala
@@ -2,10 +2,10 @@ package replcalc.eval
 
 final case class MultiplyDivide(left: Expression, right: Expression, isDivision: Boolean = false) extends Expression:
   override def evaluate: Option[Double] =
-    for {
+    for
       l <- left.evaluate
       r <- right.evaluate
-    } yield
+    yield
       if isDivision then l / r else l * r
 
 object MultiplyDivide extends Parseable[MultiplyDivide]:
@@ -15,10 +15,10 @@ object MultiplyDivide extends Parseable[MultiplyDivide]:
     val divIndex = trimmed.lastIndexOf("/")
     val (index, isDivision) = if mulIndex > divIndex then (mulIndex, false) else (divIndex, true)
     if index > 0 && index < trimmed.length - 1 then
-      for {
+      for 
         left  <- Expression.parse(trimmed.substring(0, index))
         right <- Expression.parse(trimmed.substring(index + 1))
-      } yield
+      yield
         MultiplyDivide(left, right, isDivision)
     else
       None


### PR DESCRIPTION
Here I try to make the `Expression` class a bit more generic so that when I change the result types of parsing and evaluating it won't require so big changes. Instead of relying on `Option.orElse` for traversing possible stages (e.g. should I now parse it as a "+"? No? A "*" then? Also no? How about a unary "-"?...) I put those stages in a sequence of functions and then use `Seq.collectFirst` to find the first that can handle the expression.