### PR TITLE
feat: Display meaningful errors #3 - From Option[Expression] to Option[Either[Error, Expression]]

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -317,7 +317,7 @@ modification has been made.
 
   If you convey an object code work under this section in, or with, or
 specifically for use in, a User Product, and the conveying occurs as
-part of a transaction in which the right of possession and use of the
+part of a transaction in which the rExpr of possession and use of the
 User Product is transferred to the recipient in perpetuity or for a
 fixed term (regardless of how the transaction is characterized), the
 Corresponding Source conveyed under this section must be accompanied
@@ -456,7 +456,7 @@ organization, or merging organizations.  If propagation of a covered
 work results from an entity transaction, each party to that
 transaction who receives a copy of the work also receives whatever
 licenses to the work the party's predecessor in interest had or could
-give under the previous paragraph, plus a right to possession of the
+give under the previous paragraph, plus a rExpr to possession of the
 Corresponding Source of the work from the predecessor in interest, if
 the predecessor has it or can get it with reasonable efforts.
 
@@ -480,7 +480,7 @@ hereafter acquired, that would be infringed by some manner, permitted
 by this License, of making, using, or selling its contributor version,
 but do not include claims that would be infringed only as a
 consequence of further modification of the contributor version.  For
-purposes of this definition, "control" includes the right to grant
+purposes of this definition, "control" includes the rExpr to grant
 patent sublicenses in a manner consistent with the requirements of
 this License.
 

--- a/src/main/scala/replcalc/Main.scala
+++ b/src/main/scala/replcalc/Main.scala
@@ -13,7 +13,7 @@ def main(args: String*): Unit =
     if text.trim == ":exit" then
       exit = true
     else
-      Expression.parse(text).flatMap(_.evaluate) match {
-        case Some(result) => println(result)
-        case None         => println("Error: Unable to parse or evaluate")
-      }
+      Expression.parse(text).map(_.flatMap(_.evaluate)) match
+        case Some(Right(result)) => println(result)
+        case Some(Left(error))   => println(s"Error: ${error.msg}")
+        case None                => println(s"Error: Unable to parse the expression: $text")

--- a/src/main/scala/replcalc/eval/AddSubstract.scala
+++ b/src/main/scala/replcalc/eval/AddSubstract.scala
@@ -4,7 +4,7 @@ import scala.annotation.tailrec
 import Expression.isOperator
 
 final case class AddSubstract(left: Expression, right: Expression, isSubstraction: Boolean = false) extends Expression:
-  override def evaluate: Option[Double] =
+  override def evaluate: Either[Error, Double] =
     for
       l <- left.evaluate
       r <- right.evaluate
@@ -12,17 +12,20 @@ final case class AddSubstract(left: Expression, right: Expression, isSubstractio
       if isSubstraction then l - r else l + r
 
 object AddSubstract extends Parseable[AddSubstract]:
-  override def parse(text: String): Option[AddSubstract] =
+  override def parse(text: String): ParsedExpr[AddSubstract] =
     val trimmed = text.trim
     val plusIndex = trimmed.lastIndexOf("+")
     val minusIndex = lastBinaryMinus(text)
     val (index, isSubstraction) = if plusIndex > minusIndex then (plusIndex, false) else (minusIndex, true)
     if index > 0 && index < trimmed.length - 1 then
-      for
-        left  <- Expression.parse(trimmed.substring(0, index))
-        right <- Expression.parse(trimmed.substring(index + 1))
-      yield
-        AddSubstract(left, right, isSubstraction)
+      (for
+        lExpr <- Expression.parse(trimmed.substring(0, index))
+        rExpr <- if (lExpr.isRight) Expression.parse(trimmed.substring(index + 1)) else Some(Left(Error.Unused))
+      yield (lExpr, rExpr)).map {
+        case (Right(l), Right(r)) => Right(AddSubstract(l, r, isSubstraction))
+        case (Left(error), _)     => Left(error)
+        case (_, Left(error))     => Left(error)
+      }
     else
       None
 

--- a/src/main/scala/replcalc/eval/Constant.scala
+++ b/src/main/scala/replcalc/eval/Constant.scala
@@ -1,9 +1,10 @@
 package replcalc.eval
 
 final case class Constant(number: Double) extends Expression:
-  override def evaluate: Option[Double] = Some(number)
+  override def evaluate: Either[Error, Double] = Right(number)
 
 object Constant extends Parseable[Constant]:
-  override def parse(text: String): Option[Constant] =
-    text.trim.toDoubleOption.map(Constant.apply)
-    
+  override def parse(text: String): ParsedExpr[Constant] =
+    text.trim.toDoubleOption match 
+      case Some(d) => Some(Right(Constant(d)))
+      case None    => Some(Left(ParsingError(s"Unable to parse $text")))

--- a/src/main/scala/replcalc/eval/Error.scala
+++ b/src/main/scala/replcalc/eval/Error.scala
@@ -1,0 +1,10 @@
+package replcalc.eval
+
+sealed trait Error:
+  val msg: String
+
+final case class ParsingError(override val msg: String) extends Error
+final case class EvaluationError(override val msg: String) extends Error
+
+object Error:
+  val Unused: ParsingError = ParsingError("Unused expression")

--- a/src/main/scala/replcalc/eval/Expression.scala
+++ b/src/main/scala/replcalc/eval/Expression.scala
@@ -3,21 +3,27 @@ package replcalc.eval
 import scala.annotation.tailrec
 
 trait Expression:
-  def evaluate: Option[Double]
+  def evaluate: Either[Error, Double]
+
+type ParsedExpr[T] = Option[Either[ParsingError, T]]
+
+// feels good, might delete later
+trait Parseable[T <: Expression]:
+  def parse(text: String): ParsedExpr[T]
 
 object Expression extends Parseable[Expression]:
-  override def parse(text: String): Option[Expression] =
+  override def parse(text: String): ParsedExpr[Expression] =
     val trimmed = text.trim
     // about early returns in Scala: https://makingthematrix.wordpress.com/2021/03/09/many-happy-early-returns/
     object Parsed:
-      def unapply[T <: Expression](stage: String => Option[T]): Option[T] = stage(trimmed)
+      def unapply(stage: String => ParsedExpr[Expression]): ParsedExpr[Expression] = stage(trimmed)
     stages.collectFirst { case Parsed(expression) => expression }
 
   inline def isOperator(char: Char): Boolean = operators.contains(char)
 
   private val operators: Set[Char] = Set('+', '-', '*', '/')
 
-  private val stages = Seq(
+  private val stages: Seq[String => ParsedExpr[Expression]] = Seq(
     AddSubstract.parse,
     MultiplyDivide.parse,
     UnaryMinus.parse,

--- a/src/main/scala/replcalc/eval/MultiplyDivide.scala
+++ b/src/main/scala/replcalc/eval/MultiplyDivide.scala
@@ -1,24 +1,30 @@
 package replcalc.eval
 
 final case class MultiplyDivide(left: Expression, right: Expression, isDivision: Boolean = false) extends Expression:
-  override def evaluate: Option[Double] =
-    for
-      l <- left.evaluate
-      r <- right.evaluate
-    yield
-      if isDivision then l / r else l * r
+  override def evaluate: Either[Error, Double] =
+    (for
+      lResult <- left.evaluate
+      rResult <- right.evaluate
+    yield (lResult, rResult)).flatMap {
+      case (l, r) if isDivision && r == 0.0 => Left(EvaluationError(s"Division by zero: $l / $r"))
+      case (l, r) if isDivision             => Right(l / r)
+      case (l, r)                           => Right(l * r)
+    }
 
 object MultiplyDivide extends Parseable[MultiplyDivide]:
-  override def parse(text: String): Option[MultiplyDivide] =
+  override def parse(text: String): ParsedExpr[MultiplyDivide] =
     val trimmed = text.trim
     val mulIndex = trimmed.lastIndexOf("*")
     val divIndex = trimmed.lastIndexOf("/")
     val (index, isDivision) = if mulIndex > divIndex then (mulIndex, false) else (divIndex, true)
     if index > 0 && index < trimmed.length - 1 then
-      for 
-        left  <- Expression.parse(trimmed.substring(0, index))
-        right <- Expression.parse(trimmed.substring(index + 1))
-      yield
-        MultiplyDivide(left, right, isDivision)
+      (for
+        lExpr <- Expression.parse(trimmed.substring(0, index))
+        rExpr <- if (lExpr.isRight) Expression.parse(trimmed.substring(index + 1)) else Some(Left(Error.Unused))
+      yield(lExpr, rExpr)).map {
+        case (Right(l), Right(r)) => Right(MultiplyDivide(l, r, isDivision))
+        case (Left(error), _)     => Left(error)
+        case (_, Left(error))     => Left(error)
+      }
     else
       None

--- a/src/main/scala/replcalc/eval/Parseable.scala
+++ b/src/main/scala/replcalc/eval/Parseable.scala
@@ -1,5 +1,0 @@
-package replcalc.eval
-
-// feels good, might delete later
-trait Parseable[T <: Expression]:
-  def parse(text: String): Option[T]

--- a/src/main/scala/replcalc/eval/Text.scala
+++ b/src/main/scala/replcalc/eval/Text.scala
@@ -1,8 +1,11 @@
 package replcalc.eval
 
 final case class Text(text: String) extends Expression:
-  override def evaluate: Option[Double] =
-    Expression.parse(text).flatMap(_.evaluate)
+  override def evaluate: Either[Error, Double] =
+    Expression.parse(text.trim) match
+      case Some(Right(expression)) => expression.evaluate
+      case Some(Left(error))       => Left(error)
+      case None                    => Left(EvaluationError(s"Text: Unable to evaluate $text"))
 
 object Text extends Parseable[Text]:
-  override def parse(text: String): Option[Text] = Some(Text(text.trim))
+  override def parse(text: String): ParsedExpr[Text] = Some(Right(Text(text.trim)))

--- a/src/main/scala/replcalc/eval/UnaryMinus.scala
+++ b/src/main/scala/replcalc/eval/UnaryMinus.scala
@@ -1,12 +1,12 @@
 package replcalc.eval
 
 final case class UnaryMinus(innerExpr: Expression) extends Expression:
-  override def evaluate: Option[Double] = innerExpr.evaluate.map(-_)
+  override def evaluate: Either[Error, Double] = innerExpr.evaluate.map(-_)
   
 object UnaryMinus extends Parseable[UnaryMinus]:
-  override def parse(text: String): Option[UnaryMinus] =
+  override def parse(text: String): ParsedExpr[UnaryMinus] =
     val trimmed = text.trim
     if trimmed.length > 1 && trimmed.charAt(0) == '-' then
-      Expression.parse(trimmed.substring(1)).map(UnaryMinus.apply)
+      Expression.parse(trimmed.substring(1)).map(_.map(UnaryMinus.apply))
     else 
       None


### PR DESCRIPTION
The `Left` of `Either` carries errors, the `None` of `Option` means we should look further in the sequence of stages as the current one is not applicable. `Option[Either[Error, Expression]]` is a bit too wordy for my liking (so I created an alias), but the alternative I considered, an enum with cases for a valid expression, an error, and a "none", had its own issues too.