### PR TITLE
feat: Introduce a dictionary for assigned expressions

### DIFF
--- a/src/main/scala/replcalc/Main.scala
+++ b/src/main/scala/replcalc/Main.scala
@@ -1,10 +1,11 @@
 package replcalc
 
-import replcalc.eval.Parser
+import replcalc.eval.{Parser, Dictionary}
 import scala.io.StdIn.readLine
 
 @main
 def main(args: String*): Unit =
+  val dictionary = Dictionary()
   var exit = false
   while !exit do
     print("> ")
@@ -12,7 +13,7 @@ def main(args: String*): Unit =
     if line.trim == ":exit" then
       exit = true
     else
-      Parser.parse(line).map(_.flatMap(_.evaluate)) match
+      Parser.parse(line, dictionary).map(_.flatMap(_.evaluate)) match
         case Some(Right(result)) => println(result)
         case Some(Left(error))   => println(s"Error: ${error.msg}")
         case None                => println(s"Error: Unable to parse the expression: $line")

--- a/src/main/scala/replcalc/eval/AddSubstract.scala
+++ b/src/main/scala/replcalc/eval/AddSubstract.scala
@@ -12,15 +12,15 @@ final case class AddSubstract(left: Expression, right: Expression, isSubstractio
       if isSubstraction then l - r else l + r
 
 object AddSubstract extends Parseable[AddSubstract]:
-  override def parse(line: String): ParsedExpr[AddSubstract] =
+  override def parse(line: String, dictionary: Dictionary): ParsedExpr[AddSubstract] =
     val trimmed = line.trim
     val plusIndex = trimmed.lastIndexOf("+")
     val minusIndex = lastBinaryMinus(line)
     val (index, isSubstraction) = if plusIndex > minusIndex then (plusIndex, false) else (minusIndex, true)
     if index > 0 && index < trimmed.length - 1 then
       (for
-        lExpr <- Parser.parse(trimmed.substring(0, index))
-        rExpr <- if (lExpr.isRight) Parser.parse(trimmed.substring(index + 1)) else Some(Left(Error.Unused))
+        lExpr <- Parser.parse(trimmed.substring(0, index), dictionary)
+        rExpr <- if (lExpr.isRight) Parser.parse(trimmed.substring(index + 1), dictionary) else Some(Left(Error.Unused))
       yield (lExpr, rExpr)).map {
         case (Right(l), Right(r)) => Right(AddSubstract(l, r, isSubstraction))
         case (Left(error), _)     => Left(error)

--- a/src/main/scala/replcalc/eval/Assignment.scala
+++ b/src/main/scala/replcalc/eval/Assignment.scala
@@ -6,7 +6,7 @@ final case class Assignment(name: String, expression: Expression) extends Expres
   override def evaluate: Either[Error, Double] = expression.evaluate
 
 object Assignment extends Parseable[Assignment]:
-  override def parse(line: String): ParsedExpr[Assignment] =
+  override def parse(line: String, dictionary: Dictionary): ParsedExpr[Assignment] =
     if !line.contains("=") then
       None
     else
@@ -15,11 +15,17 @@ object Assignment extends Parseable[Assignment]:
       val exprStr = line.substring(assignIndex + 1).trim
       if !isValidName(name) then
         Some(Left(ParsingError(s"Invalid value name: $name")))
+      else if dictionary.contains(name) then
+        Some(Left(ParsingError(s"The value $name is already defined")))
       else
-        Parser.parse(exprStr) match
-          case Some(Right(expression)) => Some(Right(Assignment(name, expression)))
-          case Some(Left(error))       => Some(Left(error))
-          case None                    => Some(Left(ParsingError(s"Unable to parse: $exprStr")))
+        Parser.parse(exprStr, dictionary) match
+          case Some(Right(expression)) =>
+            dictionary.add(name, expression)
+            Some(Right(Assignment(name, expression)))
+          case Some(Left(error)) =>
+            Some(Left(error))
+          case None =>
+            Some(Left(ParsingError(s"Unable to parse: $exprStr")))
 
   private def isValidName(name: String): Boolean =
     name.nonEmpty &&

--- a/src/main/scala/replcalc/eval/Constant.scala
+++ b/src/main/scala/replcalc/eval/Constant.scala
@@ -6,7 +6,7 @@ final case class Constant(number: Double) extends Expression:
   override def evaluate: Either[Error, Double] = Right(number)
 
 object Constant extends Parseable[Constant]:
-  override def parse(line: String): ParsedExpr[Constant] =
+  override def parse(line: String, dictionary: Dictionary): ParsedExpr[Constant] =
     line.trim.toDoubleOption match
       case Some(d) => Some(Right(Constant(d)))
       case None    => Some(Left(ParsingError(s"Unable to parse: $line")))

--- a/src/main/scala/replcalc/eval/Dictionary.scala
+++ b/src/main/scala/replcalc/eval/Dictionary.scala
@@ -1,0 +1,12 @@
+package replcalc.eval
+
+class Dictionary(private var expressions: Map[String, Expression] = Map.empty):
+  def add(name: String, expression: Expression): Boolean =
+    if expressions.contains(name) then false
+    else 
+      expressions += name -> expression
+      true
+
+  def get(name: String): Option[Expression] = expressions.get(name)
+  
+  def contains(name: String): Boolean = expressions.contains(name)

--- a/src/main/scala/replcalc/eval/MultiplyDivide.scala
+++ b/src/main/scala/replcalc/eval/MultiplyDivide.scala
@@ -14,15 +14,15 @@ final case class MultiplyDivide(left: Expression, right: Expression, isDivision:
     }
 
 object MultiplyDivide extends Parseable[MultiplyDivide]:
-  override def parse(line: String): ParsedExpr[MultiplyDivide] =
+  override def parse(line: String, dictionary: Dictionary): ParsedExpr[MultiplyDivide] =
     val trimmed = line.trim
     val mulIndex = trimmed.lastIndexOf("*")
     val divIndex = trimmed.lastIndexOf("/")
     val (index, isDivision) = if mulIndex > divIndex then (mulIndex, false) else (divIndex, true)
     if index > 0 && index < trimmed.length - 1 then
       (for
-        lExpr <- Parser.parse(trimmed.substring(0, index))
-        rExpr <- if (lExpr.isRight) Parser.parse(trimmed.substring(index + 1)) else Some(Left(Error.Unused))
+        lExpr <- Parser.parse(trimmed.substring(0, index), dictionary)
+        rExpr <- if (lExpr.isRight) Parser.parse(trimmed.substring(index + 1), dictionary) else Some(Left(Error.Unused))
       yield (lExpr, rExpr)).map {
         case (Right(l), Right(r)) => Right(MultiplyDivide(l, r, isDivision))
         case (Left(error), _)     => Left(error)

--- a/src/main/scala/replcalc/eval/Parser.scala
+++ b/src/main/scala/replcalc/eval/Parser.scala
@@ -5,21 +5,21 @@ import replcalc.eval.Error.ParsingError
 type ParsedExpr[T] = Option[Either[ParsingError, T]]
 
 trait Parseable[T <: Expression]:
-  def parse(line: String): ParsedExpr[T]
+  def parse(line: String, dictionary: Dictionary): ParsedExpr[T]
 
 object Parser extends Parseable[Expression]:
-  override def parse(line: String): ParsedExpr[Expression] =
+  override def parse(line: String, dictionary: Dictionary): ParsedExpr[Expression] =
     val trimmed = line.trim
     // about early returns in Scala: https://makingthematrix.wordpress.com/2021/03/09/many-happy-early-returns/
     object Parsed:
-      def unapply(stage: String => ParsedExpr[Expression]): ParsedExpr[Expression] = stage(trimmed)
+      def unapply(stage: (String, Dictionary) => ParsedExpr[Expression]): ParsedExpr[Expression] = stage(trimmed, dictionary)
     stages.collectFirst { case Parsed(expression) => expression }
-
+      
   inline def isOperator(char: Char): Boolean = operators.contains(char)
 
   private val operators: Set[Char] = Set('+', '-', '*', '/')
 
-  private val stages: Seq[String => ParsedExpr[Expression]] = Seq(
+  private val stages: Seq[(String, Dictionary) => ParsedExpr[Expression]] = Seq(
     Assignment.parse,
     AddSubstract.parse,
     MultiplyDivide.parse,

--- a/src/main/scala/replcalc/eval/UnaryMinus.scala
+++ b/src/main/scala/replcalc/eval/UnaryMinus.scala
@@ -6,9 +6,9 @@ final case class UnaryMinus(innerExpr: Expression) extends Expression:
   override def evaluate: Either[Error, Double] = innerExpr.evaluate.map(-_)
   
 object UnaryMinus extends Parseable[UnaryMinus]:
-  override def parse(line: String): ParsedExpr[UnaryMinus] =
+  override def parse(line: String, dictionary: Dictionary): ParsedExpr[UnaryMinus] =
     val trimmed = line.trim
     if trimmed.length > 1 && trimmed.charAt(0) == '-' then
-      Parser.parse(trimmed.substring(1)).map(_.map(UnaryMinus.apply))
+      Parser.parse(trimmed.substring(1), dictionary).map(_.map(UnaryMinus.apply))
     else 
       None

--- a/src/test/scala/replcalc/eval/DictionaryTest.scala
+++ b/src/test/scala/replcalc/eval/DictionaryTest.scala
@@ -1,0 +1,19 @@
+package replcalc.eval
+
+import munit.Location
+
+class DictionaryTest extends munit.FunSuite:
+  implicit val location: Location = Location.empty
+
+  test("Add and get an expression") {
+    val dict = Dictionary()
+    dict.add("a", Constant(1.0))
+    assertEquals(dict.get("a"), Some(Constant(1.0)))
+  }
+
+  test("Unable to reassign an expression") {
+    val dict = Dictionary()
+    assertEquals(dict.add("a", Constant(1.0)), true)
+    assertEquals(dict.add("a", Constant(2.0)), false)
+    assertEquals(dict.get("a"), Some(Constant(1.0)))
+  }


### PR DESCRIPTION
https://github.com/makingthematrix/replcalc/projects/1#card-74102015

Assignments have side-effects: they not only parse expressions, but also save them in the memory for further use.For a moment I experimented with an idea how to do it and still avoid side-effects. It led me to write something like a Finite State Machine where the whole REPL is na FSM, it starts with some initial state, with each line given by the user the machine generates a new state, and then awaits for another line within this new state. But I decided that it would be too complicated for what I want to do here. Instead, I made a mutable `Dictionary` which is passed around from one expression to another and slowly accumulates named expressions. It's not as "pure FP" as it could be but it works well. It's an example of how everything in programming can be done in more than one way.

Mind you, it's still more FP than if I made the `Dictionary` as a singleton and then every `Assignment` would have
a hardcoded reference to it. That would be ugly. And not good for unit testing. ;)