### PR TITLE
feat: List values in REPL

### DIFF
--- a/src/main/scala/replcalc/Main.scala
+++ b/src/main/scala/replcalc/Main.scala
@@ -5,15 +5,29 @@ import scala.io.StdIn.readLine
 
 @main
 def main(args: String*): Unit =
-  val dictionary = Dictionary()
+  val dict = Dictionary()
   var exit = false
   while !exit do
     print("> ")
     val line = readLine()
-    if line.trim == ":exit" then
+    val trimmed = line.trim
+    if trimmed == ":exit" then 
       exit = true
-    else
-      Parser.parse(line, dictionary).map(_.flatMap(_.evaluate)) match
-        case Some(Right(result)) => println(result)
-        case Some(Left(error))   => println(s"Error: ${error.msg}")
-        case None                => println(s"Error: Unable to parse the expression: $line")
+    else if trimmed == ":list" then 
+      listValues(dict)
+    else 
+      parseLine(trimmed, dict)
+
+private def listValues(dict: Dictionary): Unit =
+  dict.listNames.toSeq.sorted.foreach { name =>
+    dict.get(name).map(_.evaluate).foreach {
+      case Right(result) => println(s"$name -> $result")
+      case Left(error)   => println(s"Error when evaluating $name: ${error.msg}")
+    }
+  }
+  
+private def parseLine(line: String, dict: Dictionary): Unit =
+  Parser.parse(line, dict).map(_.flatMap(_.evaluate)) match
+    case Some(Right(result)) => println(result)
+    case Some(Left(error))   => println(s"Error: ${error.msg}")
+    case None                => println(s"Error: Unable to parse the expression: $line")

--- a/src/main/scala/replcalc/eval/AddSubstract.scala
+++ b/src/main/scala/replcalc/eval/AddSubstract.scala
@@ -12,15 +12,15 @@ final case class AddSubstract(left: Expression, right: Expression, isSubstractio
       if isSubstraction then l - r else l + r
 
 object AddSubstract extends Parseable[AddSubstract]:
-  override def parse(line: String, dictionary: Dictionary): ParsedExpr[AddSubstract] =
+  override def parse(line: String, dict: Dictionary): ParsedExpr[AddSubstract] =
     val trimmed = line.trim
     val plusIndex = trimmed.lastIndexOf("+")
     val minusIndex = lastBinaryMinus(line)
     val (index, isSubstraction) = if plusIndex > minusIndex then (plusIndex, false) else (minusIndex, true)
     if index > 0 && index < trimmed.length - 1 then
       (for
-        lExpr <- Parser.parse(trimmed.substring(0, index), dictionary)
-        rExpr <- if (lExpr.isRight) Parser.parse(trimmed.substring(index + 1), dictionary) else Some(Left(Error.Unused))
+        lExpr <- Parser.parse(trimmed.substring(0, index), dict)
+        rExpr <- if (lExpr.isRight) Parser.parse(trimmed.substring(index + 1), dict) else Some(Left(Error.Unused))
       yield (lExpr, rExpr)).map {
         case (Right(l), Right(r)) => Right(AddSubstract(l, r, isSubstraction))
         case (Left(error), _)     => Left(error)

--- a/src/main/scala/replcalc/eval/Assignment.scala
+++ b/src/main/scala/replcalc/eval/Assignment.scala
@@ -6,7 +6,7 @@ final case class Assignment(name: String, expression: Expression) extends Expres
   override def evaluate: Either[Error, Double] = expression.evaluate
 
 object Assignment extends Parseable[Assignment]:
-  override def parse(line: String, dictionary: Dictionary): ParsedExpr[Assignment] =
+  override def parse(line: String, dict: Dictionary): ParsedExpr[Assignment] =
     if !line.contains("=") then
       None
     else
@@ -15,12 +15,12 @@ object Assignment extends Parseable[Assignment]:
       val exprStr = line.substring(assignIndex + 1).trim
       if !isValidName(name) then
         Some(Left(ParsingError(s"Invalid value name: $name")))
-      else if dictionary.contains(name) then
+      else if dict.contains(name) then
         Some(Left(ParsingError(s"The value $name is already defined")))
       else
-        Parser.parse(exprStr, dictionary) match
+        Parser.parse(exprStr, dict) match
           case Some(Right(expression)) =>
-            dictionary.add(name, expression)
+            dict.add(name, expression)
             Some(Right(Assignment(name, expression)))
           case Some(Left(error)) =>
             Some(Left(error))

--- a/src/main/scala/replcalc/eval/Constant.scala
+++ b/src/main/scala/replcalc/eval/Constant.scala
@@ -6,7 +6,7 @@ final case class Constant(number: Double) extends Expression:
   override def evaluate: Either[Error, Double] = Right(number)
 
 object Constant extends Parseable[Constant]:
-  override def parse(line: String, dictionary: Dictionary): ParsedExpr[Constant] =
+  override def parse(line: String, dict: Dictionary): ParsedExpr[Constant] =
     line.trim.toDoubleOption match
       case Some(d) => Some(Right(Constant(d)))
       case None    => Some(Left(ParsingError(s"Unable to parse: $line")))

--- a/src/main/scala/replcalc/eval/Dictionary.scala
+++ b/src/main/scala/replcalc/eval/Dictionary.scala
@@ -10,3 +10,5 @@ class Dictionary(private var expressions: Map[String, Expression] = Map.empty):
   def get(name: String): Option[Expression] = expressions.get(name)
   
   def contains(name: String): Boolean = expressions.contains(name)
+  
+  def listNames: Set[String] = expressions.keySet

--- a/src/main/scala/replcalc/eval/MultiplyDivide.scala
+++ b/src/main/scala/replcalc/eval/MultiplyDivide.scala
@@ -14,15 +14,15 @@ final case class MultiplyDivide(left: Expression, right: Expression, isDivision:
     }
 
 object MultiplyDivide extends Parseable[MultiplyDivide]:
-  override def parse(line: String, dictionary: Dictionary): ParsedExpr[MultiplyDivide] =
+  override def parse(line: String, dict: Dictionary): ParsedExpr[MultiplyDivide] =
     val trimmed = line.trim
     val mulIndex = trimmed.lastIndexOf("*")
     val divIndex = trimmed.lastIndexOf("/")
     val (index, isDivision) = if mulIndex > divIndex then (mulIndex, false) else (divIndex, true)
     if index > 0 && index < trimmed.length - 1 then
       (for
-        lExpr <- Parser.parse(trimmed.substring(0, index), dictionary)
-        rExpr <- if (lExpr.isRight) Parser.parse(trimmed.substring(index + 1), dictionary) else Some(Left(Error.Unused))
+        lExpr <- Parser.parse(trimmed.substring(0, index), dict)
+        rExpr <- if (lExpr.isRight) Parser.parse(trimmed.substring(index + 1), dict) else Some(Left(Error.Unused))
       yield (lExpr, rExpr)).map {
         case (Right(l), Right(r)) => Right(MultiplyDivide(l, r, isDivision))
         case (Left(error), _)     => Left(error)

--- a/src/main/scala/replcalc/eval/Parser.scala
+++ b/src/main/scala/replcalc/eval/Parser.scala
@@ -5,24 +5,23 @@ import replcalc.eval.Error.ParsingError
 type ParsedExpr[T] = Option[Either[ParsingError, T]]
 
 trait Parseable[T <: Expression]:
-  def parse(line: String, dictionary: Dictionary): ParsedExpr[T]
+  def parse(line: String, dict: Dictionary): ParsedExpr[T]
 
 object Parser extends Parseable[Expression]:
-  override def parse(line: String, dictionary: Dictionary): ParsedExpr[Expression] =
+  override def parse(line: String, dict: Dictionary): ParsedExpr[Expression] =
     val trimmed = line.trim
     // about early returns in Scala: https://makingthematrix.wordpress.com/2021/03/09/many-happy-early-returns/
     object Parsed:
-      def unapply(stage: (String, Dictionary) => ParsedExpr[Expression]): ParsedExpr[Expression] = stage(trimmed, dictionary)
+      def unapply(stage: (String, Dictionary) => ParsedExpr[Expression]): ParsedExpr[Expression] = stage(trimmed, dict)
     stages.collectFirst { case Parsed(expression) => expression }
       
   inline def isOperator(char: Char): Boolean = operators.contains(char)
 
   private val operators: Set[Char] = Set('+', '-', '*', '/')
 
-  private val stages: Seq[(String, Dictionary) => ParsedExpr[Expression]] = Seq(
-    Assignment.parse,
-    AddSubstract.parse,
-    MultiplyDivide.parse,
-    UnaryMinus.parse,
-    Constant.parse
-  )
+  private val stages: Seq[(String, Dictionary) => ParsedExpr[Expression]] =
+    Seq(Assignment.parse,
+        AddSubstract.parse,
+        MultiplyDivide.parse,
+        UnaryMinus.parse,
+        Constant.parse)

--- a/src/main/scala/replcalc/eval/UnaryMinus.scala
+++ b/src/main/scala/replcalc/eval/UnaryMinus.scala
@@ -6,9 +6,9 @@ final case class UnaryMinus(innerExpr: Expression) extends Expression:
   override def evaluate: Either[Error, Double] = innerExpr.evaluate.map(-_)
   
 object UnaryMinus extends Parseable[UnaryMinus]:
-  override def parse(line: String, dictionary: Dictionary): ParsedExpr[UnaryMinus] =
+  override def parse(line: String, dict: Dictionary): ParsedExpr[UnaryMinus] =
     val trimmed = line.trim
     if trimmed.length > 1 && trimmed.charAt(0) == '-' then
-      Parser.parse(trimmed.substring(1), dictionary).map(_.map(UnaryMinus.apply))
+      Parser.parse(trimmed.substring(1), dict).map(_.map(UnaryMinus.apply))
     else 
       None

--- a/src/test/scala/replcalc/eval/DictionaryTest.scala
+++ b/src/test/scala/replcalc/eval/DictionaryTest.scala
@@ -17,3 +17,10 @@ class DictionaryTest extends munit.FunSuite:
     assertEquals(dict.add("a", Constant(2.0)), false)
     assertEquals(dict.get("a"), Some(Constant(1.0)))
   }
+
+  test("List values") {
+    val dict = Dictionary()
+    dict.add("a", Constant(1.0))
+    dict.add("b", Constant(2.0))
+    assertEquals(dict.listNames, Set("a", "b"))
+  }


### PR DESCRIPTION
Here I introduce a second command, after ":exit". This one is called ":list" and displays all the values that were accumulated in the dictionary so far. Note that if there was an error during parsing of the assignment, the error will prevent the assignment from being added to the dictionary. But, for example, "a = 1 / 0" is a perfectly valid assignment. It will be added and only during evaluation we will get an error that we try to divide by zero. That's why it is possible that we will see errors on the displayed list.