### PR TITLE
feat: Use values in expressions

### DIFF
--- a/src/main/scala/replcalc/eval/Assignment.scala
+++ b/src/main/scala/replcalc/eval/Assignment.scala
@@ -13,7 +13,7 @@ object Assignment extends Parseable[Assignment]:
       val assignIndex = line.indexOf('=')
       val name = line.substring(0, assignIndex).trim
       val exprStr = line.substring(assignIndex + 1).trim
-      if !isValidName(name) then
+      if !Value.isValidValueName(name) then
         Some(Left(ParsingError(s"Invalid value name: $name")))
       else if dict.contains(name) then
         Some(Left(ParsingError(s"The value $name is already defined")))
@@ -26,8 +26,3 @@ object Assignment extends Parseable[Assignment]:
             Some(Left(error))
           case None =>
             Some(Left(ParsingError(s"Unable to parse: $exprStr")))
-
-  private def isValidName(name: String): Boolean =
-    name.nonEmpty &&
-      (name(0).isLetter || name(0) == '_') &&
-      (name.substring(1).forall(ch => ch.isLetterOrDigit || ch == '_'))

--- a/src/main/scala/replcalc/eval/Parser.scala
+++ b/src/main/scala/replcalc/eval/Parser.scala
@@ -24,4 +24,5 @@ object Parser extends Parseable[Expression]:
         AddSubstract.parse,
         MultiplyDivide.parse,
         UnaryMinus.parse,
+        Value.parse,
         Constant.parse)

--- a/src/main/scala/replcalc/eval/Value.scala
+++ b/src/main/scala/replcalc/eval/Value.scala
@@ -1,0 +1,21 @@
+package replcalc.eval
+
+import Error.ParsingError
+
+final case class Value(name: String, expr: Expression) extends Expression:
+  override def evaluate: Either[Error, Double] = expr.evaluate
+  
+object Value extends Parseable[Value]:
+  override def parse(line: String, dict: Dictionary): ParsedExpr[Value] =
+    val trimmed = line.trim
+    if !isValidValueName(trimmed) then 
+      None
+    else  
+      dict.get(trimmed) match
+        case Some(expr) => Some(Right(Value(trimmed, expr)))
+        case None       => Some(Left(ParsingError(s"Value not found: $trimmed")))
+
+  def isValidValueName(name: String): Boolean =
+    name.nonEmpty &&
+      (name(0).isLetter || name(0) == '_') &&
+      name.substring(1).forall(ch => ch.isLetterOrDigit || ch == '_')

--- a/src/test/scala/replcalc/eval/DictionaryTest.scala
+++ b/src/test/scala/replcalc/eval/DictionaryTest.scala
@@ -18,9 +18,15 @@ class DictionaryTest extends munit.FunSuite:
     assertEquals(dict.get("a"), Some(Constant(1.0)))
   }
 
-  test("List values") {
+  test("List names") {
     val dict = Dictionary()
     dict.add("a", Constant(1.0))
     dict.add("b", Constant(2.0))
     assertEquals(dict.listNames, Set("a", "b"))
+  }
+
+  test("Handle an attempt to get an unassigned expression") {
+    val dict = Dictionary()
+    dict.add("a", Constant(1.0))
+    assertEquals(dict.get("b"), None)
   }

--- a/src/test/scala/replcalc/eval/ExpressionTest.scala
+++ b/src/test/scala/replcalc/eval/ExpressionTest.scala
@@ -105,3 +105,23 @@ class ExpressionTest extends munit.FunSuite:
     eval("a = 1", 1.0, dict = dict)
     shouldReturnParsingError(" a = 2", dict = dict)
   }
+
+  test("Use an assigned expression in another expression") {
+    val dict = Dictionary()
+    eval("a = 1", 1.0, dict = dict)
+    eval("a + 1", 2.0, dict = dict)
+  }
+
+  test("Use more than one assigned expression in another expression") {
+    val dict = Dictionary()
+    eval("a = 1", 1.0, dict = dict)
+    eval("b = 2", 2.0, dict = dict)
+    eval("c = a + b", 3.0, dict = dict)
+  }
+
+  test("Handle and error when the value is not assigned") {
+    val dict = Dictionary()
+    eval("a = 1", 1.0, dict = dict)
+    eval("b = 2", 2.0, dict = dict)
+    shouldReturnParsingError("c = d + e", dict = dict)
+  }


### PR DESCRIPTION
https://github.com/makingthematrix/replcalc/projects/1#card-74102091

After a valid assignment, the user is now able to use the name of the assigned expression as a value in all later expressions. So, if for example I write first `a = 1`, from this moment I'm able to do something like `b = a + 1`. The expression assigned to `a` will be taken from the dictionary and will become a part of a more complex expression that will be assigned to `b`, which from this moement I can also use to create even more complex expressions.

Maybe this is also a good moment to answer the questions what about reassignments - if I have `a = 1`, can I now do `a = 2`? And the answer is "no". Choose another name. The reason is that this is supposed to be just a calculator, not a compiler of a small programming language (yet) so I think it's more important for the user to be safe and unable to make errors than to be able to introduce more complexity. With reassignments and the fact that the program evaluates expressions on demand (expressions are "lazy", so to say), this would be possible:
```
a = 0
b = a + 1
a = b + 1
a
```
Here, first we create `a`, then `b`, and then we reassign `a`, so that now `b` is an inner expression of `a` and `a` is an inner expression of `b`. And then we try to evaluate `a` which starts an infinite recursion of evaluation.

So, no. No reassignments. At least for now.