### PR TITLE
feat: Create the preprocessor class and use it to remove whitespaces

### DIFF
--- a/src/main/scala/replcalc/eval/Constant.scala
+++ b/src/main/scala/replcalc/eval/Constant.scala
@@ -7,6 +7,6 @@ final case class Constant(number: Double) extends Expression:
 
 object Constant extends Parseable[Constant]:
   override def parse(line: String, dict: Dictionary): ParsedExpr[Constant] =
-    line.trim.toDoubleOption match
+    line.toDoubleOption match
       case Some(d) => Some(Right(Constant(d)))
       case None    => Some(Left(ParsingError(s"Unable to parse: $line")))

--- a/src/main/scala/replcalc/eval/MultiplyDivide.scala
+++ b/src/main/scala/replcalc/eval/MultiplyDivide.scala
@@ -15,14 +15,13 @@ final case class MultiplyDivide(left: Expression, right: Expression, isDivision:
 
 object MultiplyDivide extends Parseable[MultiplyDivide]:
   override def parse(line: String, dict: Dictionary): ParsedExpr[MultiplyDivide] =
-    val trimmed = line.trim
-    val mulIndex = trimmed.lastIndexOf("*")
-    val divIndex = trimmed.lastIndexOf("/")
+    val mulIndex = line.lastIndexOf("*")
+    val divIndex = line.lastIndexOf("/")
     val (index, isDivision) = if mulIndex > divIndex then (mulIndex, false) else (divIndex, true)
-    if index > 0 && index < trimmed.length - 1 then
+    if index > 0 && index < line.length - 1 then
       (for
-        lExpr <- Parser.parse(trimmed.substring(0, index), dict)
-        rExpr <- if (lExpr.isRight) Parser.parse(trimmed.substring(index + 1), dict) else Some(Left(Error.Unused))
+        lExpr <- Parser.parse(line.substring(0, index), dict)
+        rExpr <- if (lExpr.isRight) Parser.parse(line.substring(index + 1), dict) else Some(Left(Error.Unused))
       yield (lExpr, rExpr)).map {
         case (Right(l), Right(r)) => Right(MultiplyDivide(l, r, isDivision))
         case (Left(error), _)     => Left(error)

--- a/src/main/scala/replcalc/eval/Parser.scala
+++ b/src/main/scala/replcalc/eval/Parser.scala
@@ -9,12 +9,14 @@ trait Parseable[T <: Expression]:
 
 object Parser extends Parseable[Expression]:
   override def parse(line: String, dict: Dictionary): ParsedExpr[Expression] =
-    val trimmed = line.trim
+    val processed = pre.process(line)
     // about early returns in Scala: https://makingthematrix.wordpress.com/2021/03/09/many-happy-early-returns/
     object Parsed:
-      def unapply(stage: (String, Dictionary) => ParsedExpr[Expression]): ParsedExpr[Expression] = stage(trimmed, dict)
+      def unapply(stage: (String, Dictionary) => ParsedExpr[Expression]): ParsedExpr[Expression] = stage(processed, dict)
     stages.collectFirst { case Parsed(expr) => expr }
       
+  private val pre = Preprocessor()  
+    
   inline def isOperator(char: Char): Boolean = operators.contains(char)
 
   private val operators: Set[Char] = Set('+', '-', '*', '/')

--- a/src/main/scala/replcalc/eval/Preprocessor.scala
+++ b/src/main/scala/replcalc/eval/Preprocessor.scala
@@ -1,0 +1,15 @@
+package replcalc.eval
+
+class Preprocessor:
+  def process(line: String): String =
+    removeWhitespaces(line)
+    
+  private def removeWhitespaces(line: String): String =
+    if line.forall(!_.isWhitespace) then line
+    else
+      val sb = StringBuilder()
+      line.foreach {
+        case ch if !ch.isWhitespace => sb.addOne(ch)
+        case _ =>
+      }
+      sb.toString

--- a/src/main/scala/replcalc/eval/UnaryMinus.scala
+++ b/src/main/scala/replcalc/eval/UnaryMinus.scala
@@ -7,8 +7,7 @@ final case class UnaryMinus(innerExpr: Expression) extends Expression:
   
 object UnaryMinus extends Parseable[UnaryMinus]:
   override def parse(line: String, dict: Dictionary): ParsedExpr[UnaryMinus] =
-    val trimmed = line.trim
-    if trimmed.length > 1 && trimmed.charAt(0) == '-' then
-      Parser.parse(trimmed.substring(1), dict).map(_.map(UnaryMinus.apply))
+    if line.length > 1 && line.charAt(0) == '-' then
+      Parser.parse(line.substring(1), dict).map(_.map(UnaryMinus.apply))
     else 
       None

--- a/src/main/scala/replcalc/eval/Value.scala
+++ b/src/main/scala/replcalc/eval/Value.scala
@@ -7,13 +7,12 @@ final case class Value(name: String, expr: Expression) extends Expression:
   
 object Value extends Parseable[Value]:
   override def parse(line: String, dict: Dictionary): ParsedExpr[Value] =
-    val trimmed = line.trim
-    if !isValidValueName(trimmed) then 
+    if !isValidValueName(line) then 
       None
     else  
-      dict.get(trimmed) match
-        case Some(expr) => Some(Right(Value(trimmed, expr)))
-        case None       => Some(Left(ParsingError(s"Value not found: $trimmed")))
+      dict.get(line) match
+        case Some(expr) => Some(Right(Value(line, expr)))
+        case None       => Some(Left(ParsingError(s"Value not found: $line")))
 
   def isValidValueName(name: String): Boolean =
     name.nonEmpty &&

--- a/src/test/scala/replcalc/eval/PreprocessorTest.scala
+++ b/src/test/scala/replcalc/eval/PreprocessorTest.scala
@@ -1,0 +1,20 @@
+package replcalc.eval
+
+import munit.Location
+
+class PreprocessorTest extends munit.FunSuite:
+  implicit val location: Location = Location.empty
+
+  test("Do nothing if the line does not contain whitespaces") {
+    val pre = Preprocessor()
+    val line = "abcdef"
+    assertEquals(pre.process(line), line)
+  }
+
+  test("Remove whitespaces from the line") {
+    val pre = Preprocessor()
+    assertEquals(pre.process("abc def"), "abcdef")
+    assertEquals(pre.process(" abc def"), "abcdef")
+    assertEquals(pre.process("abc def "), "abcdef")
+    assertEquals(pre.process(" ab cd ef "), "abcdef")
+  }


### PR DESCRIPTION
https://github.com/makingthematrix/replcalc/projects/1#card-74102386

While the parser transforms a line of text into an AST of expressions, the preprocessor only performs some operation on the line, making it easier for the parser to work on it later. The first task of the preprocessor is to remove all the whitespaces - they are never significant and their presence in the line make the parsing more complicated (all the trimming...).

Since now the preprocessor takes care of all whitespaces, I can simplify code in the expression subtypes.