### PR TITLE
refactor: Refactor Parser for more flexible use

### DIFF
--- a/src/main/scala/replcalc/Main.scala
+++ b/src/main/scala/replcalc/Main.scala
@@ -1,12 +1,15 @@
 package replcalc
 
-import replcalc.eval.{Assignment, Dictionary, Parser}
+import replcalc.eval.{Assignment, Dictionary, Parser, Preprocessor}
 
 import scala.io.StdIn.readLine
 
 @main
 def main(args: String*): Unit =
+  val pre = Preprocessor()
   val dict = Dictionary()
+  val parser = Parser(pre, dict)
+
   var exit = false
   while !exit do
     print("> ")
@@ -17,7 +20,7 @@ def main(args: String*): Unit =
     else if trimmed == ":list" then 
       listValues(dict)
     else 
-      parseLine(trimmed, dict).foreach(println)
+      parseLine(parser, trimmed).foreach(println)
 
 private def listValues(dict: Dictionary): Unit =
   dict.listNames.toSeq.sorted.foreach { name =>
@@ -27,8 +30,8 @@ private def listValues(dict: Dictionary): Unit =
     }
   }
   
-private def parseLine(line: String, dict: Dictionary): Option[String] =
-  Parser.parse(line, dict).map {
+private def parseLine(parser: Parser, line: String): Option[String] =
+  parser.parse(line).map {
     case Right(Assignment(name, expr)) =>
       expr.evaluate match
         case Right(result) => s"$name -> $result"

--- a/src/main/scala/replcalc/eval/AddSubstract.scala
+++ b/src/main/scala/replcalc/eval/AddSubstract.scala
@@ -12,14 +12,14 @@ final case class AddSubstract(left: Expression, right: Expression, isSubstractio
       if isSubstraction then l - r else l + r
 
 object AddSubstract extends Parseable[AddSubstract]:
-  override def parse(line: String, dict: Dictionary): ParsedExpr[AddSubstract] =
+  override def parse(line: String, parser: Parser): ParsedExpr[AddSubstract] =
     val plusIndex = line.lastIndexOf("+")
     val minusIndex = lastBinaryMinus(line)
     val (index, isSubstraction) = if plusIndex > minusIndex then (plusIndex, false) else (minusIndex, true)
     if index > 0 && index < line.length - 1 then
       (for
-        lExpr <- Parser.parse(line.substring(0, index), dict)
-        rExpr <- if (lExpr.isRight) Parser.parse(line.substring(index + 1), dict) else Some(Left(Error.Unused))
+        lExpr <- parser.parse(line.substring(0, index))
+        rExpr <- if (lExpr.isRight) parser.parse(line.substring(index + 1)) else Some(Left(Error.Unused))
       yield (lExpr, rExpr)).map {
         case (Right(l), Right(r)) => Right(AddSubstract(l, r, isSubstraction))
         case (Left(error), _)     => Left(error)

--- a/src/main/scala/replcalc/eval/Assignment.scala
+++ b/src/main/scala/replcalc/eval/Assignment.scala
@@ -6,7 +6,7 @@ final case class Assignment(name: String, expr: Expression) extends Expression:
   override def evaluate: Either[Error, Double] = expr.evaluate
 
 object Assignment extends Parseable[Assignment]:
-  override def parse(line: String, dict: Dictionary): ParsedExpr[Assignment] =
+  override def parse(line: String, parser: Parser): ParsedExpr[Assignment] =
     if !line.contains("=") then
       None
     else
@@ -15,12 +15,12 @@ object Assignment extends Parseable[Assignment]:
       val exprStr = line.substring(assignIndex + 1).trim
       if !Value.isValidValueName(name) then
         Some(Left(ParsingError(s"Invalid value name: $name")))
-      else if dict.contains(name) then
+      else if parser.containsValue(name) then
         Some(Left(ParsingError(s"The value $name is already defined")))
       else
-        Parser.parse(exprStr, dict) match
+        parser.parse(exprStr) match
           case Some(Right(expression)) =>
-            dict.add(name, expression)
+            parser.addValue(name, expression)
             Some(Right(Assignment(name, expression)))
           case Some(Left(error)) =>
             Some(Left(error))

--- a/src/main/scala/replcalc/eval/Constant.scala
+++ b/src/main/scala/replcalc/eval/Constant.scala
@@ -6,7 +6,7 @@ final case class Constant(number: Double) extends Expression:
   override def evaluate: Either[Error, Double] = Right(number)
 
 object Constant extends Parseable[Constant]:
-  override def parse(line: String, dict: Dictionary): ParsedExpr[Constant] =
+  override def parse(line: String, parser: Parser): ParsedExpr[Constant] =
     line.toDoubleOption match
       case Some(d) => Some(Right(Constant(d)))
       case None    => Some(Left(ParsingError(s"Unable to parse: $line")))

--- a/src/main/scala/replcalc/eval/MultiplyDivide.scala
+++ b/src/main/scala/replcalc/eval/MultiplyDivide.scala
@@ -14,14 +14,14 @@ final case class MultiplyDivide(left: Expression, right: Expression, isDivision:
     }
 
 object MultiplyDivide extends Parseable[MultiplyDivide]:
-  override def parse(line: String, dict: Dictionary): ParsedExpr[MultiplyDivide] =
+  override def parse(line: String, parser: Parser): ParsedExpr[MultiplyDivide] =
     val mulIndex = line.lastIndexOf("*")
     val divIndex = line.lastIndexOf("/")
     val (index, isDivision) = if mulIndex > divIndex then (mulIndex, false) else (divIndex, true)
     if index > 0 && index < line.length - 1 then
       (for
-        lExpr <- Parser.parse(line.substring(0, index), dict)
-        rExpr <- if (lExpr.isRight) Parser.parse(line.substring(index + 1), dict) else Some(Left(Error.Unused))
+        lExpr <- parser.parse(line.substring(0, index))
+        rExpr <- if (lExpr.isRight) parser.parse(line.substring(index + 1)) else Some(Left(Error.Unused))
       yield (lExpr, rExpr)).map {
         case (Right(l), Right(r)) => Right(MultiplyDivide(l, r, isDivision))
         case (Left(error), _)     => Left(error)

--- a/src/main/scala/replcalc/eval/Parser.scala
+++ b/src/main/scala/replcalc/eval/Parser.scala
@@ -5,26 +5,34 @@ import replcalc.eval.Error.ParsingError
 type ParsedExpr[T] = Option[Either[ParsingError, T]]
 
 trait Parseable[T <: Expression]:
-  def parse(line: String, dict: Dictionary): ParsedExpr[T]
+  def parse(line: String, parser: Parser): ParsedExpr[T]
 
-object Parser extends Parseable[Expression]:
-  override def parse(line: String, dict: Dictionary): ParsedExpr[Expression] =
+final class Parser(pre: Preprocessor, dict: Dictionary):
+  self =>
+  import Parser.*
+
+  def parse(line: String): ParsedExpr[Expression] =
     val processed = pre.process(line)
     // about early returns in Scala: https://makingthematrix.wordpress.com/2021/03/09/many-happy-early-returns/
     object Parsed:
-      def unapply(stage: (String, Dictionary) => ParsedExpr[Expression]): ParsedExpr[Expression] = stage(processed, dict)
+      def unapply(stage: (String, Parser) => ParsedExpr[Expression]): ParsedExpr[Expression] = stage(processed, self)
     stages.collectFirst { case Parsed(expr) => expr }
-      
-  private val pre = Preprocessor()  
-    
+
+  inline def getValue(name: String): Option[Expression] = dict.get(name)
+
+  inline def addValue(name: String, expr: Expression): Boolean = dict.add(name, expr)
+
+  inline def containsValue(name: String): Boolean = dict.contains(name)
+
+object Parser:
   inline def isOperator(char: Char): Boolean = operators.contains(char)
 
   private val operators: Set[Char] = Set('+', '-', '*', '/')
 
-  private val stages: Seq[(String, Dictionary) => ParsedExpr[Expression]] =
+  private val stages: Seq[(String, Parser) => ParsedExpr[Expression]] =
     Seq(Assignment.parse,
-        AddSubstract.parse,
-        MultiplyDivide.parse,
-        UnaryMinus.parse,
-        Value.parse,
-        Constant.parse)
+      AddSubstract.parse,
+      MultiplyDivide.parse,
+      UnaryMinus.parse,
+      Value.parse,
+      Constant.parse)

--- a/src/main/scala/replcalc/eval/Preprocessor.scala
+++ b/src/main/scala/replcalc/eval/Preprocessor.scala
@@ -1,9 +1,9 @@
 package replcalc.eval
 
-class Preprocessor:
+class Preprocessor():
   def process(line: String): String =
     removeWhitespaces(line)
-    
+
   private def removeWhitespaces(line: String): String =
     if line.forall(!_.isWhitespace) then line
     else

--- a/src/main/scala/replcalc/eval/UnaryMinus.scala
+++ b/src/main/scala/replcalc/eval/UnaryMinus.scala
@@ -6,8 +6,8 @@ final case class UnaryMinus(innerExpr: Expression) extends Expression:
   override def evaluate: Either[Error, Double] = innerExpr.evaluate.map(-_)
   
 object UnaryMinus extends Parseable[UnaryMinus]:
-  override def parse(line: String, dict: Dictionary): ParsedExpr[UnaryMinus] =
+  override def parse(line: String, parser: Parser): ParsedExpr[UnaryMinus] =
     if line.length > 1 && line.charAt(0) == '-' then
-      Parser.parse(line.substring(1), dict).map(_.map(UnaryMinus.apply))
+      parser.parse(line.substring(1)).map(_.map(UnaryMinus.apply))
     else 
       None

--- a/src/main/scala/replcalc/eval/Value.scala
+++ b/src/main/scala/replcalc/eval/Value.scala
@@ -6,11 +6,11 @@ final case class Value(name: String, expr: Expression) extends Expression:
   override def evaluate: Either[Error, Double] = expr.evaluate
   
 object Value extends Parseable[Value]:
-  override def parse(line: String, dict: Dictionary): ParsedExpr[Value] =
+  override def parse(line: String, parser: Parser): ParsedExpr[Value] =
     if !isValidValueName(line) then 
       None
     else  
-      dict.get(line) match
+      parser.getValue(line) match
         case Some(expr) => Some(Right(Value(line, expr)))
         case None       => Some(Left(ParsingError(s"Value not found: $line")))
 


### PR DESCRIPTION
So far the `Parser` functionality was simple enough that everything could be contained within one method, `parse`. But after I made `Dictionary`, and now with `Preprocessor`, the code starts to get more complex. To make the future work easier I decided to change `Parser` from a Scala `object` into a regular `class` instance with references to the preprocessor and the dictionary.