### PR TITLE
feat: Handle parentheses

### DIFF
--- a/src/main/scala/replcalc/Dictionary.scala
+++ b/src/main/scala/replcalc/Dictionary.scala
@@ -13,4 +13,8 @@ final class Dictionary(private var expressions: Map[String, Expression] = Map.em
 
   inline def contains(name: String): Boolean = expressions.contains(name)
 
-  inline def listNames: Set[String] = expressions.keySet
+  inline def listNames(withSpecial: Boolean = false): Set[String] = 
+    if withSpecial then
+      expressions.keySet
+    else 
+      expressions.keySet.filter(_(0) != '$')

--- a/src/main/scala/replcalc/Main.scala
+++ b/src/main/scala/replcalc/Main.scala
@@ -6,9 +6,8 @@ import scala.io.StdIn.readLine
 
 @main
 def main(args: String*): Unit =
-  val pre = Preprocessor()
   val dict = Dictionary()
-  val parser = Parser(pre, dict)
+  lazy val parser = Parser(dict)
 
   var exit = false
   while !exit do
@@ -23,7 +22,7 @@ def main(args: String*): Unit =
       parseLine(parser, trimmed).foreach(println)
 
 private def listValues(dict: Dictionary): Unit =
-  dict.listNames.toSeq.sorted.foreach { name =>
+  dict.listNames().toSeq.sorted.foreach { name =>
     dict.get(name).map(_.evaluate).foreach {
       case Right(result) => println(s"$name -> $result")
       case Left(error)   => println(s"Error when evaluating $name: ${error.msg}")

--- a/src/main/scala/replcalc/Preprocessor.scala
+++ b/src/main/scala/replcalc/Preprocessor.scala
@@ -1,15 +1,59 @@
 package replcalc
 
-class Preprocessor():
-  def process(line: String): String =
-    removeWhitespaces(line)
+import replcalc.expressions.Error.ParsingError
 
-  private def removeWhitespaces(line: String): String =
-    if line.forall(!_.isWhitespace) then line
+import scala.annotation.tailrec
+
+final class Preprocessor(parser: Parser):
+  private var specialValuesCounter = 0L
+
+  def process(line: String): Either[ParsingError, String] =
+    for {
+      noWhitespaces <- removeWhitespaces(line)
+      noParentheses <- removeParentheses(noWhitespaces)
+    } yield noParentheses
+
+  private def removeWhitespaces(line: String): Either[ParsingError, String] =
+    if line.forall(!_.isWhitespace) then
+      Right(line)
     else
       val sb = StringBuilder()
       line.foreach {
         case ch if !ch.isWhitespace => sb.addOne(ch)
         case _ =>
       }
-      sb.toString
+      Right(sb.toString)
+
+  @tailrec
+  private def removeParentheses(line: String): Either[ParsingError, String] =
+    val opening = line.indexOf("(")
+    if opening == -1 then
+      Right(line)
+    else
+      findMatchingParens(line.substring(opening)) match
+        case Some(index) =>
+          val closing = opening + index
+          parser.parse(line.substring(opening + 1, closing)) match
+            case Some(Right(expr)) =>
+              specialValuesCounter += 1
+              val name = s"$$$specialValuesCounter"
+              parser.addValue(name, expr)
+              removeParentheses(s"${line.substring(0, opening)}$name${line.substring(closing + 1)}")
+            case Some(Left(error)) =>
+              Left(error)
+            case None =>
+              Left(ParsingError(s"Preprocessor: Unable to parse: $line"))
+        case None =>
+          Left(ParsingError(s"Preprocessor: Unable to find the matching closing parenthesis: $line"))
+
+  private def findMatchingParens(expr: String): Option[Int] =
+    if expr.isEmpty then None
+    else
+      val (index, counter) = expr.drop(1).foldLeft((0, 1)) {
+        case ((index, 0), _)                         => (index, 0)
+        case ((index, counter), '(')                 => (index + 1, counter + 1)
+        case ((index, counter), ')') if counter == 0 => (index, counter - 1)
+        case ((index, counter), ')')                 => (index + 1, counter - 1)
+        case ((index, counter), _)                   => (index + 1, counter)
+      }
+      if counter == 0 then Some(index) else None

--- a/src/main/scala/replcalc/expressions/Value.scala
+++ b/src/main/scala/replcalc/expressions/Value.scala
@@ -8,14 +8,14 @@ final case class Value(name: String, expr: Expression) extends Expression:
   
 object Value extends Parseable[Value]:
   override def parse(line: String, parser: Parser): ParsedExpr[Value] =
-    if !isValidValueName(line) then 
+    if !isValidValueName(line, true) then 
       None
     else  
       parser.getValue(line) match
         case Some(expr) => Some(Right(Value(line, expr)))
         case None       => Some(Left(ParsingError(s"Value not found: $line")))
 
-  def isValidValueName(name: String): Boolean =
+  def isValidValueName(name: String, canBeSpecial: Boolean = false): Boolean =
     name.nonEmpty &&
-      (name(0).isLetter || name(0) == '_') &&
+      (name(0).isLetter || name(0) == '_' || (canBeSpecial && name(0) == '$')) &&
       name.substring(1).forall(ch => ch.isLetterOrDigit || ch == '_')

--- a/src/test/scala/replcalc/DictionaryTest.scala
+++ b/src/test/scala/replcalc/DictionaryTest.scala
@@ -23,7 +23,7 @@ class DictionaryTest extends munit.FunSuite:
     val dict = Dictionary()
     dict.add("a", Constant(1.0))
     dict.add("b", Constant(2.0))
-    assertEquals(dict.listNames, Set("a", "b"))
+    assertEquals(dict.listNames(), Set("a", "b"))
   }
 
   test("Handle an attempt to get an unassigned expression") {

--- a/src/test/scala/replcalc/ExpressionTest.scala
+++ b/src/test/scala/replcalc/ExpressionTest.scala
@@ -138,3 +138,12 @@ class ExpressionTest extends munit.FunSuite:
     eval("b = 2", 2.0)
     shouldReturnParsingError("c = d + e")
   }
+
+  test("Expressions with parentheses") {
+    implicit def parser: Parser = createParser()
+    eval("1 + (2 + 3) + 4", 10.0)
+    eval("1 - (2 + 3) - 4", -8.0)
+    eval("-(3*-2)", 6.0)
+    eval("(2+3)*2", 10.0)
+    eval("1 + ((2 * 3) - 4) / 5", 1.4)
+  }

--- a/src/test/scala/replcalc/ExpressionTest.scala
+++ b/src/test/scala/replcalc/ExpressionTest.scala
@@ -5,7 +5,7 @@ import munit.{ComparisonFailException, Location}
 class ExpressionTest extends munit.FunSuite:
   implicit val location: Location = Location.empty
 
-  private def createParser(pre: Preprocessor = Preprocessor(), dict: Dictionary = Dictionary()): Parser = Parser(pre, dict)
+  private def createParser(dict: Dictionary = Dictionary()): Parser = Parser(dict)
 
   private def eval(str: String, expected: Double, delta: Double = 0.001)(implicit parser: Parser) =
     parser.parse(str) match

--- a/src/test/scala/replcalc/PreprocessorTest.scala
+++ b/src/test/scala/replcalc/PreprocessorTest.scala
@@ -12,7 +12,6 @@ class PreprocessorTest extends munit.FunSuite:
       case Left(error) =>
         fail(s"Parsing error: ${error.msg}")
       case Right(result) =>
-        println(s"result: $result")
         assert(result.startsWith(prefix))
         assert(result.endsWith(suffix))
         assert(!result.contains("("))

--- a/src/test/scala/replcalc/PreprocessorTest.scala
+++ b/src/test/scala/replcalc/PreprocessorTest.scala
@@ -5,16 +5,63 @@ import munit.Location
 class PreprocessorTest extends munit.FunSuite:
   implicit val location: Location = Location.empty
 
+  private def pre = Parser().preprocessor
+
+  private def evalParens(line: String, prefix: String = "", suffix: String = ""): Unit =
+    pre.process(line) match
+      case Left(error) =>
+        fail(s"Parsing error: ${error.msg}")
+      case Right(result) =>
+        println(s"result: $result")
+        assert(result.startsWith(prefix))
+        assert(result.endsWith(suffix))
+        assert(!result.contains("("))
+        assert(!result.contains(")"))
+        assert(result.length > prefix.length + suffix.length)
+
+  private def shouldFailParens(line: String): Unit =
+    pre.process(line) match
+      case Left(error) =>
+      case Right(result) => fail(s"Unfortunately this is working just fine: $line")
+
   test("Do nothing if the line does not contain whitespaces") {
-    val pre = Preprocessor()
     val line = "abcdef"
-    assertEquals(pre.process(line), line)
+    assertEquals(pre.process(line), Right(line))
   }
 
   test("Remove whitespaces from the line") {
-    val pre = Preprocessor()
-    assertEquals(pre.process("abc def"), "abcdef")
-    assertEquals(pre.process(" abc def"), "abcdef")
-    assertEquals(pre.process("abc def "), "abcdef")
-    assertEquals(pre.process(" ab cd ef "), "abcdef")
+    assertEquals(pre.process("abc def"), Right("abcdef"))
+    assertEquals(pre.process(" abc def"), Right("abcdef"))
+    assertEquals(pre.process("abc def "), Right("abcdef"))
+    assertEquals(pre.process(" ab cd ef "), Right("abcdef"))
+  }
+
+  test("Replace parentheses with a special value") {
+    evalParens("1+(2+3)+4", "1+", "+4")
+    evalParens("(1+2)")
+    evalParens("(1+2)+3", "", "+3")
+    evalParens("1+(2+3)", "1+", "")
+  }
+
+  test("Handle more than one set of parentheses") {
+    evalParens("1+(2+3)+(4+5)+6", "1+", "+6")
+    evalParens("(1+2)+3+(4+5)")
+    evalParens("(1+2)+(4+5)")
+    evalParens("1+(2+3)+(4+5)", "1+")
+    evalParens("(2+3)+(4+5)+6", "", "+6")
+    evalParens("1+(2+3)+(4+5)+(6+7)+8", "1+", "+8")
+  }
+
+  test("Handle nested parentheses") {
+    evalParens("1+(2+(3+4)+5)+6", "1+", "+6")
+    evalParens("(1+(2+(3+4)+5))+6", "", "+6")
+    evalParens("1+((2+(3+4)+5)+6)", "1+", "")
+  }
+
+  test("Handle unclosed paretheses") {
+    shouldFailParens("(")
+    shouldFailParens("((")
+    shouldFailParens("(1+2)+(")
+    shouldFailParens("(1+(2+(3+4)+5)+6")
+    shouldFailParens("1+((2+(3+4)+5)+6")
   }


### PR DESCRIPTION
 https://github.com/makingthematrix/replcalc/projects/1#card-74101822
    
There is no special expression type for parentheses. Instead, parentheses are turned to special variables by the preprocessor. Each pair of parentheses is parsed as an individual, smaller expression, added to the dictionary under a special name, and then it's replaced in the original like by that special name. For example "1 + (2 + 3) + 4" becomes "1 + $1 + 4" where "$1" is the name of the variable. In the dictionary we now have an expression "2 + 3" under this name. When evaluated, the variable  "$1" will be replaced with the result of "2 + 3" and used to evaluate the rest of the higher-level expression.
