### PR TITLE
refactor: Find expressions for values at evaluation

### DIFF
--- a/src/main/scala/replcalc/Main.scala
+++ b/src/main/scala/replcalc/Main.scala
@@ -6,8 +6,7 @@ import scala.io.StdIn.readLine
 
 @main
 def main(args: String*): Unit =
-  val dict = Dictionary()
-  lazy val parser = Parser(dict)
+  lazy val parser = Parser()
 
   var exit = false
   while !exit do
@@ -17,26 +16,26 @@ def main(args: String*): Unit =
     if trimmed == ":exit" then 
       exit = true
     else if trimmed == ":list" then 
-      listValues(dict)
-    else 
-      parseLine(parser, trimmed).foreach(println)
+      listValues(parser.dictionary)
+    else
+      evaluate(trimmed, parser).foreach(println)
 
 private def listValues(dict: Dictionary): Unit =
   dict.listNames().toSeq.sorted.foreach { name =>
-    dict.get(name).map(_.evaluate).foreach {
+    dict.get(name).map(_.evaluate(dict)).foreach {
       case Right(result) => println(s"$name -> $result")
       case Left(error)   => println(s"Error when evaluating $name: ${error.msg}")
     }
   }
   
-private def parseLine(parser: Parser, line: String): Option[String] =
+private def evaluate(line: String, parser: Parser): Option[String] =
   parser.parse(line).map {
     case Right(Assignment(name, expr)) =>
-      expr.evaluate match
+      expr.evaluate(parser.dictionary) match
         case Right(result) => s"$name -> $result"
         case Left(error)   => s"$name -> Evaluation error: ${error.msg}"
     case Right(expr) =>
-      expr.evaluate match
+      expr.evaluate(parser.dictionary) match
         case Right(result) => s"$result"
         case Left(error)   => s"Evaluation error: ${error.msg}"
     case Left(error) =>

--- a/src/main/scala/replcalc/Parser.scala
+++ b/src/main/scala/replcalc/Parser.scala
@@ -3,13 +3,13 @@ package replcalc
 import replcalc.expressions.*
 import replcalc.{Dictionary, Preprocessor}
 
-final class Parser(dict: Dictionary = Dictionary()):
+final class Parser(private val dict: Dictionary = Dictionary()):
   self =>
   import Parser.*
 
   private lazy val pre = Preprocessor(this)
   
-  // for tests
+  def dictionary: Dictionary = dict
   def preprocessor: Preprocessor = pre 
 
   def parse(line: String): ParsedExpr[Expression] =

--- a/src/main/scala/replcalc/expressions/AddSubstract.scala
+++ b/src/main/scala/replcalc/expressions/AddSubstract.scala
@@ -2,13 +2,13 @@ package replcalc.expressions
 
 import scala.annotation.tailrec
 import Error.ParsingError
-import replcalc.Parser
+import replcalc.{Dictionary, Parser}
 
 final case class AddSubstract(left: Expression, right: Expression, isSubstraction: Boolean = false) extends Expression:
-  override def evaluate: Either[Error, Double] =
+  override def evaluate(dict: Dictionary): Either[Error, Double] =
     for
-      l <- left.evaluate
-      r <- right.evaluate
+      l <- left.evaluate(dict)
+      r <- right.evaluate(dict)
     yield
       if isSubstraction then l - r else l + r
 

--- a/src/main/scala/replcalc/expressions/Assignment.scala
+++ b/src/main/scala/replcalc/expressions/Assignment.scala
@@ -1,10 +1,10 @@
 package replcalc.expressions
 
 import Error.*
-import replcalc.Parser
+import replcalc.{Dictionary, Parser}
 
 final case class Assignment(name: String, expr: Expression) extends Expression:
-  override def evaluate: Either[Error, Double] = expr.evaluate
+  override def evaluate(dict: Dictionary): Either[Error, Double] = expr.evaluate(dict)
 
 object Assignment extends Parseable[Assignment]:
   override def parse(line: String, parser: Parser): ParsedExpr[Assignment] =
@@ -12,13 +12,13 @@ object Assignment extends Parseable[Assignment]:
       None
     else
       val assignIndex = line.indexOf('=')
-      val name = line.substring(0, assignIndex).trim
-      val exprStr = line.substring(assignIndex + 1).trim
+      val name = line.substring(0, assignIndex)
       if !Value.isValidValueName(name) then
         Some(Left(ParsingError(s"Invalid value name: $name")))
       else if parser.containsValue(name) then
         Some(Left(ParsingError(s"The value $name is already defined")))
       else
+        val exprStr = line.substring(assignIndex + 1)
         parser.parse(exprStr) match
           case Some(Right(expression)) =>
             parser.addValue(name, expression)

--- a/src/main/scala/replcalc/expressions/Constant.scala
+++ b/src/main/scala/replcalc/expressions/Constant.scala
@@ -1,10 +1,10 @@
 package replcalc.expressions
 
 import Error.ParsingError
-import replcalc.Parser
+import replcalc.{Dictionary, Parser}
 
 final case class Constant(number: Double) extends Expression:
-  override def evaluate: Either[Error, Double] = Right(number)
+  override def evaluate(dict: Dictionary): Either[Error, Double] = Right(number)
 
 object Constant extends Parseable[Constant]:
   override def parse(line: String, parser: Parser): ParsedExpr[Constant] =

--- a/src/main/scala/replcalc/expressions/Expression.scala
+++ b/src/main/scala/replcalc/expressions/Expression.scala
@@ -1,6 +1,6 @@
 package replcalc.expressions
 
-import replcalc.Parser
+import replcalc.{Dictionary, Parser}
 import replcalc.expressions.Error.ParsingError
 
 type ParsedExpr[T] = Option[Either[ParsingError, T]]
@@ -9,5 +9,5 @@ trait Parseable[T <: Expression]:
   def parse(line: String, parser: Parser): ParsedExpr[T]
 
 trait Expression:
-  def evaluate: Either[Error, Double]
+  def evaluate(dict: Dictionary): Either[Error, Double]
 

--- a/src/main/scala/replcalc/expressions/MultiplyDivide.scala
+++ b/src/main/scala/replcalc/expressions/MultiplyDivide.scala
@@ -1,13 +1,13 @@
 package replcalc.expressions
 
 import Error.*
-import replcalc.Parser
+import replcalc.{Dictionary, Parser}
 
 final case class MultiplyDivide(left: Expression, right: Expression, isDivision: Boolean = false) extends Expression:
-  override def evaluate: Either[Error, Double] =
+  override def evaluate(dict: Dictionary): Either[Error, Double] =
     (for
-      lResult <- left.evaluate
-      rResult <- right.evaluate
+      lResult <- left.evaluate(dict)
+      rResult <- right.evaluate(dict)
     yield (lResult, rResult)).flatMap {
       case (l, r) if isDivision && r == 0.0 => Left(EvaluationError(s"Division by zero: $l / $r"))
       case (l, r) if isDivision             => Right(l / r)

--- a/src/main/scala/replcalc/expressions/UnaryMinus.scala
+++ b/src/main/scala/replcalc/expressions/UnaryMinus.scala
@@ -1,10 +1,10 @@
 package replcalc.expressions
 
 import Error.ParsingError
-import replcalc.Parser
+import replcalc.{Dictionary, Parser}
 
 final case class UnaryMinus(innerExpr: Expression) extends Expression:
-  override def evaluate: Either[Error, Double] = innerExpr.evaluate.map(-_)
+  override def evaluate(dict: Dictionary): Either[Error, Double] = innerExpr.evaluate(dict).map(-_)
   
 object UnaryMinus extends Parseable[UnaryMinus]:
   override def parse(line: String, parser: Parser): ParsedExpr[UnaryMinus] =

--- a/src/test/scala/replcalc/ExpressionTest.scala
+++ b/src/test/scala/replcalc/ExpressionTest.scala
@@ -12,7 +12,7 @@ class ExpressionTest extends munit.FunSuite:
       case None => failComparison("Parsed as 'none'", str, expected)
       case Some(Left(error)) => failComparison(s"Error: ${error.msg}", str, expected)
       case Some(Right(expr)) =>
-        expr.evaluate match
+        expr.evaluate(parser.dictionary) match
           case Right(result) => assertEqualsDouble(result, expected, delta)
           case Left(error)   => failComparison(s"Error: ${error.msg}", str, expected)
 


### PR DESCRIPTION
Until now when I found a name of a value in the parsed line, I pulled the associated expression from the dictionary during the parsing stage and made a reference to it in the value. That works well for values - which are constant - but when thinking how to implement functions I realized that for functions I won't have expressions ready at the parsing stage. Functions have arguments and expressions associated with arguments are not known when a function is created (parsing) but only when it is used (evaluation). During the parsing I prepare a template, so to say, where certain parts are waiting to be filled later.

I decided that `Value` will be used for such holes in the template. From now on a value will only hold its name, so it will be possible to use it in the template, as the program won't search for the associated expression that doesn't exist yet. Only when the function is evaluated, the program will first parse the arguments and prepare required expressions, and then when it will find a value during the evaluation of the function, it will know what expression it refers to.