### PR TITLE
feat: Enable copying and updating dictionaries

### DIFF
--- a/src/main/scala/replcalc/Dictionary.scala
+++ b/src/main/scala/replcalc/Dictionary.scala
@@ -2,19 +2,28 @@ package replcalc
 
 import replcalc.expressions.Expression
 
-final class Dictionary(private var expressions: Map[String, Expression] = Map.empty):
+final class Dictionary(private var expressions: Map[String, Expression] = Map.empty,
+                       private var specialValuesCounter: Long = 0L):
   def add(name: String, expr: Expression): Boolean =
     if expressions.contains(name) then false
-    else 
+    else
       expressions += name -> expr
       true
+
+  def addSpecial(expr: Expression): String =
+    specialValuesCounter += 1
+    val name = s"$$$specialValuesCounter"
+    expressions += name -> expr
+    name
 
   inline def get(name: String): Option[Expression] = expressions.get(name)
 
   inline def contains(name: String): Boolean = expressions.contains(name)
 
-  inline def listNames(withSpecial: Boolean = false): Set[String] = 
+  inline def listNames(withSpecial: Boolean = false): Set[String] =
     if withSpecial then
       expressions.keySet
-    else 
+    else
       expressions.keySet.filter(_(0) != '$')
+
+  def copy(updates: Map[String, Expression]): Dictionary = Dictionary(expressions ++ updates, specialValuesCounter)

--- a/src/main/scala/replcalc/Parser.scala
+++ b/src/main/scala/replcalc/Parser.scala
@@ -22,12 +22,6 @@ final class Parser(private val dict: Dictionary = Dictionary()):
           def unapply(stage: (String, Parser) => ParsedExpr[Expression]): ParsedExpr[Expression] = stage(processed, self)
         stages.collectFirst { case Parsed(expr) => expr }
 
-  inline def getValue(name: String): Option[Expression] = dict.get(name)
-
-  inline def addValue(name: String, expr: Expression): Boolean = dict.add(name, expr)
-
-  inline def containsValue(name: String): Boolean = dict.contains(name)
-
 object Parser:
   inline def isOperator(char: Char): Boolean = operators.contains(char)
 

--- a/src/main/scala/replcalc/Preprocessor.scala
+++ b/src/main/scala/replcalc/Preprocessor.scala
@@ -5,8 +5,6 @@ import replcalc.expressions.Error.ParsingError
 import scala.annotation.tailrec
 
 final class Preprocessor(parser: Parser):
-  private var specialValuesCounter = 0L
-
   def process(line: String): Either[ParsingError, String] =
     for {
       noWhitespaces <- removeWhitespaces(line)
@@ -26,7 +24,7 @@ final class Preprocessor(parser: Parser):
 
   @tailrec
   private def removeParentheses(line: String): Either[ParsingError, String] =
-    val opening = line.indexOf("(")
+    val opening = line.indexOf('(')
     if opening == -1 then
       Right(line)
     else
@@ -35,10 +33,10 @@ final class Preprocessor(parser: Parser):
           val closing = opening + index
           parser.parse(line.substring(opening + 1, closing)) match
             case Some(Right(expr)) =>
-              specialValuesCounter += 1
-              val name = s"$$$specialValuesCounter"
-              parser.addValue(name, expr)
-              removeParentheses(s"${line.substring(0, opening)}$name${line.substring(closing + 1)}")
+              val pre = line.substring(0, opening)
+              val name = parser.dictionary.addSpecial(expr)
+              val post = line.substring(closing + 1)
+              removeParentheses(s"$pre$name$post")
             case Some(Left(error)) =>
               Left(error)
             case None =>

--- a/src/main/scala/replcalc/expressions/Assignment.scala
+++ b/src/main/scala/replcalc/expressions/Assignment.scala
@@ -15,13 +15,13 @@ object Assignment extends Parseable[Assignment]:
       val name = line.substring(0, assignIndex)
       if !Value.isValidValueName(name) then
         Some(Left(ParsingError(s"Invalid value name: $name")))
-      else if parser.containsValue(name) then
+      else if parser.dictionary.contains(name) then
         Some(Left(ParsingError(s"The value $name is already defined")))
       else
         val exprStr = line.substring(assignIndex + 1)
         parser.parse(exprStr) match
           case Some(Right(expression)) =>
-            parser.addValue(name, expression)
+            parser.dictionary.add(name, expression)
             Some(Right(Assignment(name, expression)))
           case Some(Left(error)) =>
             Some(Left(error))

--- a/src/main/scala/replcalc/expressions/Value.scala
+++ b/src/main/scala/replcalc/expressions/Value.scala
@@ -15,7 +15,7 @@ object Value extends Parseable[Value]:
   override def parse(line: String, parser: Parser): ParsedExpr[Value] =
     if !isValidValueName(line, true) then 
       None
-    else if !parser.containsValue(line) then
+    else if !parser.dictionary.contains(line) then
       Some(Left(ParsingError(s"Parsing error: Value not found: $line")))
     else
       Some(Right(Value(line)))

--- a/src/test/scala/replcalc/DictionaryTest.scala
+++ b/src/test/scala/replcalc/DictionaryTest.scala
@@ -31,3 +31,10 @@ class DictionaryTest extends munit.FunSuite:
     dict.add("a", Constant(1.0))
     assertEquals(dict.get("b"), None)
   }
+
+  test("Copy with updates") {
+    val dict = Dictionary()
+    dict.add("a", Constant(1.0))
+    val newDict = dict.copy(Map("b" -> Constant(2.0)))
+    assertEquals(newDict.get("b"), Some(Constant(2.0)))
+  }


### PR DESCRIPTION
In preparation for inplementing functions, I want first to get a few things out of the way. One of them is that I will need more than one global storage for expressions, i.e. more than one dictionary. Let's say we have global values `a` and `b`, and then we create a function `foo(x)`. The global dictionary should then hold expressions for `a`, `b`, and `foo`, but not for `x`. `x` will only exist within the scope of the `foo` function. If the user tries to access `x` outside of it, they will get an error. So, I imagine that this means to solve `foo(x)` I will have to create a copy of the global dictionary but with an update - the copy will hold an expression for `x`, created just before. That copy will then be used by a (new) parser to create an expression for a given particular use of `foo(x)` - `foo(1)`, `foo(3*4)`, `foo(a+b)`, etc., and within the scope of the function the parser will be able to parse expressions using `x`. But the moment we jump out of `foo`, we will get back to using the global dictionary, which has no idea what `x` is.

This PR introduces the ability to cope the dictionary and provide updates while doing it. It also copies the special values counter so that new special values, created during parsing of the function, will not get mixed with the higher-order ones.