### PR TITLE
feat: Different rules in preprocessor for left and right sides of an assignment

### DIFF
--- a/src/main/scala/replcalc/Preprocessor.scala
+++ b/src/main/scala/replcalc/Preprocessor.scala
@@ -7,9 +7,13 @@ import scala.annotation.tailrec
 final class Preprocessor(parser: Parser):
   def process(line: String): Either[ParsingError, String] =
     for {
-      noWhitespaces <- removeWhitespaces(line)
-      noParentheses <- removeParentheses(noWhitespaces)
-    } yield noParentheses
+      line          <- removeWhitespaces(line)
+      assignIndex   =  line.indexOf('=')
+      (left, right) =  if assignIndex == -1 then ("", line)
+                       else (line.substring(0, assignIndex), line.substring(assignIndex + 1))
+      right         <- removeParentheses(right)
+    } yield
+      if left.isEmpty then right else s"${left}=${right}"
 
   private def removeWhitespaces(line: String): Either[ParsingError, String] =
     if line.forall(!_.isWhitespace) then

--- a/src/test/scala/replcalc/PreprocessorTest.scala
+++ b/src/test/scala/replcalc/PreprocessorTest.scala
@@ -5,8 +5,7 @@ import munit.Location
 class PreprocessorTest extends munit.FunSuite:
   implicit val location: Location = Location.empty
 
-  private def pre = Parser().preprocessor
-
+  private def pre: Preprocessor = Parser().preprocessor
   private def evalParens(line: String, prefix: String = "", suffix: String = ""): Unit =
     pre.process(line) match
       case Left(error) =>
@@ -40,6 +39,13 @@ class PreprocessorTest extends munit.FunSuite:
     evalParens("(1+2)")
     evalParens("(1+2)+3", "", "+3")
     evalParens("1+(2+3)", "1+", "")
+  }
+
+  test("Parentheses with assignments") {
+    evalParens("a = 1 + (2 + 3) + 4", "a=1+", "+4")
+    evalParens("b = (1 + 2)")
+    evalParens("c = (1 + 2) + 3", "c=", "+3")
+    evalParens("d = 1+ (2 + 3)", "d=1+", "")
   }
 
   test("Handle more than one set of parentheses") {


### PR DESCRIPTION
Currently in the preprocessor I have logic for removing whitespaces and for turning parentheses into special values. This is going to get much more complicated with introduction of functions, since functions also use parentheses, but in a different way. This PR anticipates that a little bit - if the line is an assignment, removing parentheses will be now done only on the right side of it. The left side will stay the same and will be handled in the parser.