### PR TITLE
feat: Implement assignments to functions

### DIFF
--- a/src/main/scala/replcalc/Dictionary.scala
+++ b/src/main/scala/replcalc/Dictionary.scala
@@ -15,7 +15,7 @@ final class Dictionary(private var expressions: Map[String, Expression] = Map.em
     val name = s"$$$specialValuesCounter"
     expressions += name -> expr
     name
-
+  
   inline def get(name: String): Option[Expression] = expressions.get(name)
 
   inline def contains(name: String): Boolean = expressions.contains(name)
@@ -27,3 +27,4 @@ final class Dictionary(private var expressions: Map[String, Expression] = Map.em
       expressions.keySet.filter(_(0) != '$')
 
   def copy(updates: Map[String, Expression]): Dictionary = Dictionary(expressions ++ updates, specialValuesCounter)
+  

--- a/src/main/scala/replcalc/Parser.scala
+++ b/src/main/scala/replcalc/Parser.scala
@@ -29,6 +29,7 @@ object Parser:
 
   private val stages: Seq[(String, Parser) => ParsedExpr[Expression]] =
     Seq(
+      FunctionAssignment.parse,
       ValueAssignment.parse,
       AddSubstract.parse,
       MultiplyDivide.parse,

--- a/src/main/scala/replcalc/expressions/FunctionAssignment.scala
+++ b/src/main/scala/replcalc/expressions/FunctionAssignment.scala
@@ -1,0 +1,45 @@
+package replcalc.expressions
+
+import Error.*
+import replcalc.{Dictionary, Parser}
+
+final case class FunctionAssignment(name: String, args: Set[String], expr: Expression) extends Expression:
+  override def evaluate(dict: Dictionary): Either[Error, Double] = expr.evaluate(dict)
+
+object FunctionAssignment extends Parseable[FunctionAssignment]:
+  private def argsAsMap(args: Set[String]): Map[String, Expression] = args.map(arg => arg -> Value(arg)).toMap
+
+  override def parse(line: String, parser: Parser): ParsedExpr[FunctionAssignment] =
+    if !line.contains("=") then
+      None
+    else
+      val assignIndex = line.indexOf('=')
+      val name = line.substring(0, assignIndex)
+      if name.count(_ == '(') != 1 || name.count(_ == ')') != 1 then
+        None
+      else
+        parseFunction(name, line.substring(assignIndex + 1), parser)
+
+  private def parseFunction(name: String, exprStr: String, parser: Parser): ParsedExpr[FunctionAssignment] =
+    val startIndex = name.indexOf('(')
+    val endIndex = name.indexOf(')')
+    val functionName = name.substring(0, startIndex)
+    if startIndex > endIndex || !Value.isValidValueName(functionName) then
+      Some(Left(ParsingError(s"Invalid function name: $functionName")))
+    else
+      val args = name.substring(startIndex + 1, endIndex).split(",").map(_.trim).filter(_.nonEmpty).toSet
+      args.collect { case arg if !Value.isValidValueName(arg) => arg } match
+        case invalidArgs if invalidArgs.nonEmpty =>
+          Some(Left(ParsingError(s"Invalid argument(s): ${invalidArgs.mkString(", ")}")))
+        case _ =>
+          val innerDict = parser.dictionary.copy(argsAsMap(args))
+          Parser(innerDict).parse(exprStr) match
+            case Some(Right(expression)) =>
+              val assignment = FunctionAssignment(functionName, args, expression)
+              parser.dictionary.add(functionName, assignment)
+              Some(Right(assignment))
+            case Some(Left(error)) =>
+              Some(Left(error))
+            case None =>
+              Some(Left(ParsingError(s"Unable to parse: $exprStr")))
+

--- a/src/main/scala/replcalc/expressions/Value.scala
+++ b/src/main/scala/replcalc/expressions/Value.scala
@@ -5,11 +5,9 @@ import replcalc.{Dictionary, Parser}
 
 final case class Value(name: String) extends Expression:
   override def evaluate(dict: Dictionary): Either[Error, Double] =
-    dict.get(name) match {
+    dict.get(name) match
       case Some(expr) => expr.evaluate(dict)
       case None       => Left(EvaluationError(s"Evaluation error: Value not found: $name"))
-    }
-
   
 object Value extends Parseable[Value]:
   override def parse(line: String, parser: Parser): ParsedExpr[Value] =

--- a/src/test/scala/replcalc/ExpressionTest.scala
+++ b/src/test/scala/replcalc/ExpressionTest.scala
@@ -16,6 +16,12 @@ class ExpressionTest extends munit.FunSuite:
           case Right(result) => assertEqualsDouble(result, expected, delta)
           case Left(error)   => failComparison(s"Error: ${error.msg}", str, expected)
 
+  private def parse(str: String)(implicit parser: Parser) =
+    parser.parse(str) match
+      case None => fail(s"Parsed as 'none': $str")
+      case Some(Left(error)) => fail(s"Error: ${error.msg} at line $str")
+      case Some(Right(expr)) =>
+
   private def shouldReturnParsingError(line: String)(implicit parser: Parser) =
     parser.parse(line) match
       case None => fail(s"Parsed as 'none': $line")
@@ -101,7 +107,7 @@ class ExpressionTest extends munit.FunSuite:
     eval("3 - - 3", 6.0)
   }
 
-  test("Assignments") {
+  test("Value assignments") {
     implicit def parser: Parser = createParser()
     eval("a = 3", 3.0)
     eval("_a = 3", 3.0)
@@ -146,4 +152,13 @@ class ExpressionTest extends munit.FunSuite:
     eval("-(3*-2)", 6.0)
     eval("(2+3)*2", 10.0)
     eval("1 + ((2 * 3) - 4) / 5", 1.4)
+  }
+
+  test("Function assignments") {
+    implicit val parser: Parser = createParser()
+    parse("foo(x) = x + 1")
+    parse("bar() = 2 + 1")
+    parse("a = 3")
+    parse("myFunc(x) = a + x + 2")
+    shouldReturnParsingError("myFunc(x) = y")
   }


### PR DESCRIPTION
https://github.com/makingthematrix/replcalc/projects/1#card-74102362

This PR allows to create a new type of assignment, a function assignment, and add it to the dictionary.
It's not possible to use it yet. The left side of the assignment needs to be a name of the function followed by the opening parenthesis, a list of arguments names spearated with commas, and the closing parenthesis. The right side can be any expression that uses previously assigned values and arguments defined on the left side.
In theory it should also possible to use other functions, but for now evaluation of functions is not implemented, so no.