### PR TITLE
feat: When looking for parentheses in the preprocessor, ignore function parentheses

### DIFF
--- a/src/main/scala/replcalc/Parser.scala
+++ b/src/main/scala/replcalc/Parser.scala
@@ -25,7 +25,7 @@ final class Parser(private val dict: Dictionary = Dictionary()):
 object Parser:
   inline def isOperator(char: Char): Boolean = operators.contains(char)
 
-  private val operators: Set[Char] = Set('+', '-', '*', '/')
+  private val operators: Set[Char] = Set('+', '-', '*', '/', ',')
 
   private val stages: Seq[(String, Parser) => ParsedExpr[Expression]] =
     Seq(

--- a/src/main/scala/replcalc/Preprocessor.scala
+++ b/src/main/scala/replcalc/Preprocessor.scala
@@ -28,28 +28,38 @@ final class Preprocessor(parser: Parser):
 
   @tailrec
   private def removeParentheses(line: String): Either[ParsingError, String] =
-    val opening = line.indexOf('(')
-    if opening == -1 then
-      Right(line)
-    else
-      findMatchingParens(line.substring(opening)) match
-        case Some(index) =>
-          val closing = opening + index
-          parser.parse(line.substring(opening + 1, closing)) match
-            case Some(Right(expr)) =>
-              val pre = line.substring(0, opening)
-              val name = parser.dictionary.addSpecial(expr)
-              val post = line.substring(closing + 1)
-              removeParentheses(s"$pre$name$post")
-            case Some(Left(error)) =>
-              Left(error)
-            case None =>
-              Left(ParsingError(s"Preprocessor: Unable to parse: $line"))
-        case None =>
-          Left(ParsingError(s"Preprocessor: Unable to find the matching closing parenthesis: $line"))
-
+    findNonFunctionOpeningParens(line) match
+      case None => 
+        Right(line)
+      case Some(opening) =>
+        findMatchingParens(line.substring(opening)) match
+          case Some(index) =>
+            val closing = opening + index
+            parser.parse(line.substring(opening + 1, closing)) match
+              case Some(Right(expr)) =>
+                val pre = line.substring(0, opening)
+                val name = parser.dictionary.addSpecial(expr)
+                val post = line.substring(closing + 1)
+                removeParentheses(s"$pre$name$post")
+              case Some(Left(error)) =>
+                Left(error)
+              case None =>
+                Left(ParsingError(s"Preprocessor: Unable to parse: $line"))
+          case None =>
+            Left(ParsingError(s"Preprocessor: Unable to find the matching closing parenthesis: $line"))
+    
+  private def findNonFunctionOpeningParens(line: String): Option[Int] =
+    val index = line.indexOf('(')
+    if index == -1 then 
+      None
+    else if index == 0 || Parser.isOperator(line(index - 1)) then 
+      Some(index)
+    else 
+      findNonFunctionOpeningParens(line.substring(index + 1)).map(_ + index + 1)
+  
   private def findMatchingParens(expr: String): Option[Int] =
-    if expr.isEmpty then None
+    if expr.isEmpty then 
+      None
     else
       val (index, counter) = expr.drop(1).foldLeft((0, 1)) {
         case ((index, 0), _)                         => (index, 0)

--- a/src/test/scala/replcalc/PreprocessorTest.scala
+++ b/src/test/scala/replcalc/PreprocessorTest.scala
@@ -5,29 +5,35 @@ import munit.Location
 class PreprocessorTest extends munit.FunSuite:
   implicit val location: Location = Location.empty
 
-  private def pre: Preprocessor = Parser().preprocessor
-  private def evalParens(line: String, prefix: String = "", suffix: String = ""): Unit =
-    pre.process(line) match
+  private def evalParens(line: String, prefix: String = "", suffix: String = "")(implicit parser: Parser = Parser()): Unit =
+    parser.preprocessor.process(line) match
       case Left(error) =>
         fail(s"Parsing error: ${error.msg}")
       case Right(result) =>
         assert(result.startsWith(prefix))
         assert(result.endsWith(suffix))
-        assert(!result.contains("("))
-        assert(!result.contains(")"))
+        if !result.contains('=') then
+          assert(!result.contains('('))
+          assert(!result.contains(')'))
+        else
+          val rightPart = result.substring(result.indexOf('='))
+          assert(!rightPart.contains('('))
+          assert(!rightPart.contains(')'))
         assert(result.length > prefix.length + suffix.length)
 
-  private def shouldFailParens(line: String): Unit =
-    pre.process(line) match
+  private def shouldFailParens(line: String)(implicit parser: Parser = Parser()): Unit =
+    parser.preprocessor.process(line) match
       case Left(error) =>
       case Right(result) => fail(s"Unfortunately this is working just fine: $line")
 
   test("Do nothing if the line does not contain whitespaces") {
+    val pre = Parser().preprocessor
     val line = "abcdef"
     assertEquals(pre.process(line), Right(line))
   }
 
   test("Remove whitespaces from the line") {
+    val pre = Parser().preprocessor
     assertEquals(pre.process("abc def"), Right("abcdef"))
     assertEquals(pre.process(" abc def"), Right("abcdef"))
     assertEquals(pre.process("abc def "), Right("abcdef"))
@@ -35,6 +41,7 @@ class PreprocessorTest extends munit.FunSuite:
   }
 
   test("Replace parentheses with a special value") {
+    implicit val parser: Parser = Parser()
     evalParens("1+(2+3)+4", "1+", "+4")
     evalParens("(1+2)")
     evalParens("(1+2)+3", "", "+3")
@@ -42,13 +49,16 @@ class PreprocessorTest extends munit.FunSuite:
   }
 
   test("Parentheses with assignments") {
+    implicit val parser: Parser = Parser()
     evalParens("a = 1 + (2 + 3) + 4", "a=1+", "+4")
     evalParens("b = (1 + 2)")
     evalParens("c = (1 + 2) + 3", "c=", "+3")
     evalParens("d = 1+ (2 + 3)", "d=1+", "")
+    evalParens("foo(x) = 1 + (2 + 3)", "foo(x)=1+", "")
   }
 
   test("Handle more than one set of parentheses") {
+    implicit val parser: Parser = Parser()
     evalParens("1+(2+3)+(4+5)+6", "1+", "+6")
     evalParens("(1+2)+3+(4+5)")
     evalParens("(1+2)+(4+5)")
@@ -58,15 +68,52 @@ class PreprocessorTest extends munit.FunSuite:
   }
 
   test("Handle nested parentheses") {
+    implicit val parser: Parser = Parser()
     evalParens("1+(2+(3+4)+5)+6", "1+", "+6")
     evalParens("(1+(2+(3+4)+5))+6", "", "+6")
     evalParens("1+((2+(3+4)+5)+6)", "1+", "")
   }
 
   test("Handle unclosed paretheses") {
+    implicit val parser: Parser = Parser()
     shouldFailParens("(")
     shouldFailParens("((")
     shouldFailParens("(1+2)+(")
     shouldFailParens("(1+(2+(3+4)+5)+6")
     shouldFailParens("1+((2+(3+4)+5)+6")
+  }
+
+  test("Ignore function parentheses") {
+    val pre = Parser().preprocessor
+    assertEquals(pre.process("foo(1)"), Right("foo(1)"))
+    assertEquals(pre.process("foo(1)+1"), Right("foo(1)+1"))
+    assertEquals(pre.process("2+foo(3,4)"), Right("2+foo(3,4)"))
+
+    pre.process("2+foo((3+1),4)") match
+      case Right(result) =>
+        assert(result.startsWith("2+foo("))
+        assert(result.endsWith(",4)"))
+        assert(!result.contains("(3+1)"))
+      case Left(error) =>
+        fail(error.msg)
+
+    pre.process("foo((1),(2))") match
+      case Right(result) =>
+        assert(result.contains("foo("))
+        val index = result.indexOf("foo(") + 5
+        assert(result.substring(index).contains(')'))
+        assert(!result.contains("(1)"))
+        assert(!result.contains("(2)"))
+      case Left(error) =>
+        fail(error.msg)
+
+    pre.process("(1+2)+foo((3+1),(4+5))+(6+7)") match
+      case Right(result) =>
+        assert(result.contains("+foo("))
+        val index = result.indexOf("+foo(") + 5
+        assert(result.substring(index).contains(')'))
+        assert(!result.contains("(3+1)"))
+        assert(!result.contains("(4+5)"))
+      case Left(error) =>
+        fail(error.msg)
   }


### PR DESCRIPTION
https://github.com/makingthematrix/replcalc/projects/1#card-74102362

I use the same characters for denoting standard mathematical parentheses, like in `(1+2)*3` and in functions, but function parentheses work differently. In the preprocessor, where the program looks for pairs of parentheses to replace them with values, it should recognize when the opening parenthesis is one of a function and it should ignore it. However, it should not ignore mathematical parentheses in the place of arguments. For example: `1 + foo(x, y) + 2` should be left with no changes, but `1 + foo((2 + 3) * 4, 5 / (6 - 7)) + 8` should have `(2 + 3)` and `(6 - 7)` replaced with values.