### PR TITLE
refactor: Put logic about finding matching parentheses in one place

### DIFF
--- a/src/main/scala/replcalc/Parser.scala
+++ b/src/main/scala/replcalc/Parser.scala
@@ -1,7 +1,6 @@
 package replcalc
 
 import replcalc.expressions.*
-import replcalc.{Dictionary, Preprocessor}
 
 final class Parser(private val dict: Dictionary = Dictionary()):
   self =>

--- a/src/main/scala/replcalc/Preprocessor.scala
+++ b/src/main/scala/replcalc/Preprocessor.scala
@@ -1,64 +1,72 @@
 package replcalc
 
 import replcalc.Preprocessor.Flags
-import replcalc.expressions.Error.ParsingError
+import replcalc.expressions.Error
 
 import scala.annotation.tailrec
 
 final class Preprocessor(parser: Parser, flags: Flags = Flags.AllTrue):
-  def process(line: String): Either[ParsingError, String] =
+  def process(line: String): Either[Error, String] =
     for {
       line          <- if flags.removeWhitespaces then removeWhitespaces(line) else Right(line)
       assignIndex   =  line.indexOf('=')
-      (left, right) =  if assignIndex == -1 then ("", line)
-                       else (line.substring(0, assignIndex), line.substring(assignIndex + 1))
-      right         <- if flags.removeParentheses then removeParentheses(right) else Right(right)
+      (left, right) =  if assignIndex == -1 then
+                         ("", line)
+                       else
+                         (line.substring(0, assignIndex), line.substring(assignIndex + 1))
+      right         <- if flags.removeParens then removeParens(right) else Right(right)
     } yield
-      if left.isEmpty then right else s"${left}=${right}"
+      if left.isEmpty then right else s"$left=$right"
 
-  private def removeWhitespaces(line: String): Either[ParsingError, String] =
+  private def removeWhitespaces(line: String): Either[Error, String] =
     if line.forall(!_.isWhitespace) then
       Right(line)
     else
-      val sb = StringBuilder()
+      val sb = StringBuilder(line.length)
       line.foreach {
         case ch if !ch.isWhitespace => sb.addOne(ch)
         case _ =>
       }
       Right(sb.toString)
 
-  @tailrec
-  private def removeParentheses(line: String): Either[ParsingError, String] =
-    findNonFunctionOpeningParens(line) match
+  private def removeParens(line: String): Either[Error, String] =
+    withParens(line) { (opening, closing) =>
+      parser.parse(line.substring(opening + 1, closing)) match
+        case None =>
+          Left(Error.ParsingError(s"Unable to parse: $line"))
+        case Some(Left(error)) =>
+          Left(error)
+        case Some(Right(expr)) =>
+          val pre = line.substring(0, opening)
+          val name = parser.dictionary.addSpecial(expr)
+          val post = line.substring(closing + 1)
+          removeParens(s"$pre$name$post")
+    }
+
+  private def withParens(line: String)(body: (Int, Int) => Either[Error, String]): Either[Error, String] =
+    findParens(line) match
       case None =>
         Right(line)
-      case Some(opening) =>
-        findMatchingParens(line.substring(opening)) match
-          case Some(index) =>
-            val closing = opening + index
-            parser.parse(line.substring(opening + 1, closing)) match
-              case Some(Right(expr)) =>
-                val pre = line.substring(0, opening)
-                val name = parser.dictionary.addSpecial(expr)
-                val post = line.substring(closing + 1)
-                removeParentheses(s"$pre$name$post")
-              case Some(Left(error)) =>
-                Left(error)
-              case None =>
-                Left(ParsingError(s"Preprocessor: Unable to parse: $line"))
-          case None =>
-            Left(ParsingError(s"Preprocessor: Unable to find the matching closing parenthesis: $line"))
+      case Some(Left(error)) =>
+        Left(error)
+      case Some(Right(opening, closing)) =>
+        body(opening, closing)
 
-  private def findNonFunctionOpeningParens(line: String): Option[Int] =
-    val index = line.indexOf('(')
-    if index == -1 then
+  private def findParens(line: String): Option[Either[Error, (Int, Int)]] =
+    val opening = line.indexOf('(')
+    if opening == -1 then
       None
-    else if index == 0 || Parser.isOperator(line(index - 1)) then
-      Some(index)
+    else if opening == 0 || Parser.isOperator(line(opening - 1)) then
+      findClosingParens(line.substring(opening)) match
+        case None =>
+          Some(Left(Error.ParsingError(s"Unable to find the matching closing parenthesis: $line")))
+        case Some(offset) =>
+          Some(Right((opening, opening + offset)))
     else
-      findNonFunctionOpeningParens(line.substring(index + 1)).map(_ + index + 1)
+      findParens(line.substring(opening + 1))
+        .map(res => res.map { case (op, cl) => (opening + 1 + op, opening + 1 + cl) })
 
-  private def findMatchingParens(expr: String): Option[Int] =
+  private def findClosingParens(expr: String): Option[Int] =
     if expr.isEmpty then
       None
     else
@@ -73,7 +81,7 @@ final class Preprocessor(parser: Parser, flags: Flags = Flags.AllTrue):
 
 object Preprocessor:
   final case class Flags(removeWhitespaces: Boolean = true,
-                         removeParentheses: Boolean = true)
+                         removeParens: Boolean = true)
 
   object Flags:
     val AllTrue: Flags = Flags()

--- a/src/main/scala/replcalc/expressions/Expression.scala
+++ b/src/main/scala/replcalc/expressions/Expression.scala
@@ -3,7 +3,7 @@ package replcalc.expressions
 import replcalc.{Dictionary, Parser}
 import replcalc.expressions.Error.ParsingError
 
-type ParsedExpr[T] = Option[Either[ParsingError, T]]
+type ParsedExpr[T] = Option[Either[Error, T]]
 
 trait Parseable[T <: Expression]:
   def parse(line: String, parser: Parser): ParsedExpr[T]


### PR DESCRIPTION
Looking for parentheses forces me to deal with some complexity I don't really like. It is possible that there are no parentheses in the line and then the code should return `None` and this is fine, the program should move on. Or there can be parentheses and then I need to find them and do some operations on the part of the line before the opening one, some on what's after the closing one and yet something (probably the most interesting part) on what's between them. But then, it is also possible that there is the opening parenthesis but no closing one and then the code should return an error (if there is only the closing parenthesis it will also return an error but in another place).

So, I'm mostly interested in the case where I have the parentheses but I still need to write code for the two other cases.

This PR takes care of that with the help of a pattern I use sometimes in Scala: I make a method `withParens(line){ body }` that takes a function (a body) which will be called only if there are parentheses. If there are none, or if thre's only one, the method itself will handle that.

This will be useful in the next PRs where I start to implement functions.