### PR TITLE
feat: Put parentheses around functions arguments

### DIFF
--- a/src/main/scala/replcalc/Dictionary.scala
+++ b/src/main/scala/replcalc/Dictionary.scala
@@ -25,7 +25,7 @@ final class Dictionary(private var expressions: Map[String, Expression] = Map.em
     if withSpecial then
       expressions.keySet
     else
-      expressions.keySet.filter(_(0) != '$')
+      expressions.keySet.filter(_.head != '$')
 
   def copy(updates: Map[String, Expression]): Dictionary = 
     Dictionary(expressions ++ updates, specialValuesCounter)
@@ -33,5 +33,5 @@ final class Dictionary(private var expressions: Map[String, Expression] = Map.em
 object Dictionary:
   def isValidName(name: String, canBeSpecial: Boolean = false): Boolean =
     name.nonEmpty &&
-      (name(0).isLetter || name(0) == '_' || (canBeSpecial && name(0) == '$')) &&
+      (name.head.isLetter || name.head == '_' || (canBeSpecial && name.head == '$')) &&
       name.substring(1).forall(ch => ch.isLetterOrDigit || ch == '_')

--- a/src/main/scala/replcalc/Parser.scala
+++ b/src/main/scala/replcalc/Parser.scala
@@ -1,19 +1,20 @@
 package replcalc
 
+import replcalc.Preprocessor.Flags
 import replcalc.expressions.*
 
-final class Parser(private val dict: Dictionary = Dictionary()):
+final class Parser(private val dict: Dictionary = Dictionary(), preprocessorFlags: Flags = Flags.AllTrue):
   self =>
   import Parser.*
 
-  private lazy val pre = Preprocessor(this)
+  private lazy val pre = Preprocessor(this, preprocessorFlags)
   
   def dictionary: Dictionary = dict
   def preprocessor: Preprocessor = pre 
 
   def parse(line: String): ParsedExpr[Expression] =
     pre.process(line) match
-      case Left(error) => 
+      case Left(error) =>
         Some(Left(error))
       case Right(processed) =>
         // about early returns in Scala: https://makingthematrix.wordpress.com/2021/03/09/many-happy-early-returns/

--- a/src/main/scala/replcalc/Preprocessor.scala
+++ b/src/main/scala/replcalc/Preprocessor.scala
@@ -7,15 +7,13 @@ import scala.annotation.tailrec
 
 final class Preprocessor(parser: Parser, flags: Flags = Flags.AllTrue):
   def process(line: String): Either[Error, String] =
-    for {
+    for
       line          <- if flags.removeWhitespaces then removeWhitespaces(line) else Right(line)
       assignIndex   =  line.indexOf('=')
-      (left, right) =  if assignIndex == -1 then
-                         ("", line)
-                       else
-                         (line.substring(0, assignIndex), line.substring(assignIndex + 1))
+      (left, right) =  if assignIndex > 0 then (line.substring(0, assignIndex), line.substring(assignIndex + 1)) else ("", line)
+      right         <- if flags.wrapFunctionArguments then wrapFunctionArguments(right) else Right(right)
       right         <- if flags.removeParens then removeParens(right) else Right(right)
-    } yield
+    yield
       if left.isEmpty then right else s"$left=$right"
 
   private def removeWhitespaces(line: String): Either[Error, String] =
@@ -30,10 +28,10 @@ final class Preprocessor(parser: Parser, flags: Flags = Flags.AllTrue):
       Right(sb.toString)
 
   private def removeParens(line: String): Either[Error, String] =
-    withParens(line) { (opening, closing) =>
+    withParens(line, functionParens = false) { (opening, closing) =>
       parser.parse(line.substring(opening + 1, closing)) match
         case None =>
-          Left(Error.ParsingError(s"Unable to parse: $line"))
+          Left(Error.PreprocessorError(s"Unable to parse: $line"))
         case Some(Left(error)) =>
           Left(error)
         case Some(Right(expr)) =>
@@ -43,8 +41,53 @@ final class Preprocessor(parser: Parser, flags: Flags = Flags.AllTrue):
           removeParens(s"$pre$name$post")
     }
 
-  private def withParens(line: String)(body: (Int, Int) => Either[Error, String]): Either[Error, String] =
-    findParens(line) match
+  private def wrapFunctionArguments(line: String): Either[Error, String] =
+    withParens(line, functionParens = true) { (opening, closing) =>
+      val inside = line.substring(opening + 1, closing)
+      val args =
+        if inside.isEmpty then
+          Nil
+        else
+          splitByCommas(inside).map {
+            case arg if arg.forall(c => !Parser.isOperator(c)) && findParens(arg, functionParens = true).isEmpty =>
+              Right(arg)
+            case arg if arg.head == '(' && arg.last == ')' && arg.count(_ == '(') == 1 && arg.count(_ == ')') == 1 =>
+              Right(arg)
+            case arg =>
+              wrapFunctionArguments(arg).map(wrapped => s"($wrapped)")
+          }
+      args.find(_.isLeft) match
+        case Some(error) =>
+          error
+        case None =>
+          wrapFunctionArguments(line.substring(closing + 1)).map { post =>
+            val pre = line.substring(0, opening)
+            val wrapped = args.collect { case Right(arg) => arg }.mkString(",")
+            s"$pre($wrapped)$post"
+          }
+    }
+
+  private def splitByCommas(line: String): List[String] =
+    findNextComma(line) match
+      case None             => List(line)
+      case Some(commaIndex) => line.substring(0, commaIndex) :: splitByCommas(line.substring(commaIndex + 1))
+
+  private def findNextComma(line: String): Option[Int] =
+    val commaIndex = line.indexOf(',')
+    if commaIndex == -1 then
+      None
+    else if commaIndex == 0 then
+      Some(0)
+    else
+      findParens(line, true) match
+        case None                                              => Some(commaIndex)
+        case Some(Left(error))                                 => None
+        case Some(Right((opening, _))) if commaIndex < opening => Some(commaIndex)
+        case Some(Right((_, closing))) if commaIndex > closing => Some(commaIndex)
+        case Some(Right((_, closing)))                         => findNextComma(line.substring(closing + 1)).map(_ + closing + 1)
+
+  private def withParens(line: String, functionParens: Boolean)(body: (Int, Int) => Either[Error, String]): Either[Error, String] =
+    findParens(line, functionParens) match
       case None =>
         Right(line)
       case Some(Left(error)) =>
@@ -52,18 +95,20 @@ final class Preprocessor(parser: Parser, flags: Flags = Flags.AllTrue):
       case Some(Right(opening, closing)) =>
         body(opening, closing)
 
-  private def findParens(line: String): Option[Either[Error, (Int, Int)]] =
+  private def findParens(line: String, functionParens: Boolean): Option[Either[Error, (Int, Int)]] =
+    inline def isFunctionParens(line: String, atIndex: Int): Boolean = atIndex != 0 && !Parser.isOperator(line(atIndex - 1))
     val opening = line.indexOf('(')
     if opening == -1 then
       None
-    else if opening == 0 || Parser.isOperator(line(opening - 1)) then
+    else if (functionParens && isFunctionParens(line, opening)) ||
+            (!functionParens && !isFunctionParens(line, opening)) then
       findClosingParens(line.substring(opening)) match
         case None =>
-          Some(Left(Error.ParsingError(s"Unable to find the matching closing parenthesis: $line")))
+          Some(Left(Error.PreprocessorError(s"Unable to find the matching closing parenthesis: $line")))
         case Some(offset) =>
           Some(Right((opening, opening + offset)))
     else
-      findParens(line.substring(opening + 1))
+      findParens(line.substring(opening + 1), functionParens)
         .map(res => res.map { case (op, cl) => (opening + 1 + op, opening + 1 + cl) })
 
   private def findClosingParens(expr: String): Option[Int] =
@@ -81,6 +126,7 @@ final class Preprocessor(parser: Parser, flags: Flags = Flags.AllTrue):
 
 object Preprocessor:
   final case class Flags(removeWhitespaces: Boolean = true,
+                         wrapFunctionArguments: Boolean = true,
                          removeParens: Boolean = true)
 
   object Flags:

--- a/src/main/scala/replcalc/expressions/Error.scala
+++ b/src/main/scala/replcalc/expressions/Error.scala
@@ -3,6 +3,7 @@ package replcalc.expressions
 enum Error(val msg: String):
   case ParsingError(override val msg: String) extends Error(msg)
   case EvaluationError(override val msg: String) extends Error(msg)
+  case PreprocessorError(override val msg: String) extends Error(msg)
 
 object Error:
   val Unused: ParsingError = ParsingError("Unused expr")

--- a/src/main/scala/replcalc/expressions/Expression.scala
+++ b/src/main/scala/replcalc/expressions/Expression.scala
@@ -1,7 +1,7 @@
 package replcalc.expressions
 
 import replcalc.{Dictionary, Parser}
-import replcalc.expressions.Error.ParsingError
+import replcalc.expressions.Error
 
 type ParsedExpr[T] = Option[Either[Error, T]]
 

--- a/src/main/scala/replcalc/expressions/UnaryMinus.scala
+++ b/src/main/scala/replcalc/expressions/UnaryMinus.scala
@@ -8,7 +8,7 @@ final case class UnaryMinus(innerExpr: Expression) extends Expression:
   
 object UnaryMinus extends Parseable[UnaryMinus]:
   override def parse(line: String, parser: Parser): ParsedExpr[UnaryMinus] =
-    if line.length > 1 && line.charAt(0) == '-' then
+    if line.length > 1 && line.head == '-' then
       parser.parse(line.substring(1)).map(_.map(UnaryMinus.apply))
     else 
       None


### PR DESCRIPTION
https://github.com/makingthematrix/replcalc/projects/1#card-74102362

This one is a bit hacky. In preparation for implementing functions I thought about a potential problem I can run into.
Consider something like:
```
foo(1, bar(2, 3), 4)
```
We have a function `foo` which has three arguments: `1`, `bar(2, 3)`, and `3`. But how do I parse those arguments? Well, by looking for commas. So let's try to split the arguments of `foo` by commas.
```
1, 
bar(2, 
3), 
4
```
The problem is, I need to ignore that one comma which belongs to the `bar` function, but it's not easy to do. I would need to identify the `bar` function and jump over it. I can do it, I have the code for that, but in a different place. Using it at this moment would be very messy. Instead, I decided to make a new task in the preprocessor which puts parentheses around function arguments. So `foo(1, bar(2, 3), 4)` becomes `foo(1, (bar(2, 3)), 4)` (constant arguments don't need parentheses).
And then in the next task, the one about removing parentheses, this becomes `foo(1, $1, 4)` because the argument with parentheses is turned into a special value. Together the two tasks simply the function expression so it's pretty easy to parse it - no need to worry about nested expressions in arguments.