### PR TITLE
refactor: Simplify function assignments

### DIFF
--- a/src/main/scala/replcalc/expressions/FunctionAssignment.scala
+++ b/src/main/scala/replcalc/expressions/FunctionAssignment.scala
@@ -1,45 +1,48 @@
 package replcalc.expressions
 
 import Error.*
-import replcalc.{Dictionary, Parser}
+import replcalc.{Dictionary, Parser, Preprocessor}
+import scala.util.chaining.*
 
-final case class FunctionAssignment(name: String, args: Set[String], expr: Expression) extends Expression:
+final case class FunctionAssignment(name: String, argNames: Seq[String], expr: Expression) extends Expression:
   override def evaluate(dict: Dictionary): Either[Error, Double] = expr.evaluate(dict)
 
 object FunctionAssignment extends Parseable[FunctionAssignment]:
-  private def argsAsMap(args: Set[String]): Map[String, Expression] = args.map(arg => arg -> Value(arg)).toMap
-
   override def parse(line: String, parser: Parser): ParsedExpr[FunctionAssignment] =
     if !line.contains("=") then
       None
     else
       val assignIndex = line.indexOf('=')
-      val name = line.substring(0, assignIndex)
-      if name.count(_ == '(') != 1 || name.count(_ == ')') != 1 then
-        None
-      else
-        parseFunction(name, line.substring(assignIndex + 1), parser)
+      val left = line.substring(0, assignIndex)
+      Preprocessor.findParens(left, functionParens = true).flatMap {
+        case Left(error) =>
+          Some(Left(error))
+        case Right((opening, closing)) =>
+          val functionName = left.substring(0, opening)
+          val argsStr = left.substring(opening + 1, closing)
+          val right = line.substring(assignIndex + 1)
+          parseFunction(functionName, argsStr, right, parser)
+      }
 
-  private def parseFunction(name: String, exprStr: String, parser: Parser): ParsedExpr[FunctionAssignment] =
-    val startIndex = name.indexOf('(')
-    val endIndex = name.indexOf(')')
-    val functionName = name.substring(0, startIndex)
-    if startIndex > endIndex || !Dictionary.isValidName(functionName) then
+  private def parseFunction(functionName: String, argsStr: String, exprStr: String, parser: Parser): ParsedExpr[FunctionAssignment] =
+    if !Dictionary.isValidName(functionName) then
       Some(Left(ParsingError(s"Invalid function name: $functionName")))
     else
-      val args = name.substring(startIndex + 1, endIndex).split(",").map(_.trim).filter(_.nonEmpty).toSet
-      args.collect { case arg if !Dictionary.isValidName(arg) => arg } match
+      val argNames = argsStr.split(",").map(_.trim).filter(_.nonEmpty).toSeq
+      val error = argNames.collect { case argName if !Dictionary.isValidName(argName) => argName }
+      error match
         case invalidArgs if invalidArgs.nonEmpty =>
           Some(Left(ParsingError(s"Invalid argument(s): ${invalidArgs.mkString(", ")}")))
         case _ =>
-          val innerDict = parser.dictionary.copy(argsAsMap(args))
+          val argsMap = argNames.map(name => name -> Value(name)).toMap
+          val innerDict = parser.dictionary.copy(argsMap)
           Parser(innerDict).parse(exprStr) match
             case Some(Right(expression)) =>
-              val assignment = FunctionAssignment(functionName, args, expression)
-              parser.dictionary.add(functionName, assignment)
-              Some(Right(assignment))
+              FunctionAssignment(functionName, argNames, expression).pipe { assignment =>
+                parser.dictionary.add(functionName, assignment)
+                Some(Right(assignment))
+              }
             case Some(Left(error)) =>
               Some(Left(error))
             case None =>
               Some(Left(ParsingError(s"Unable to parse: $exprStr")))
-


### PR DESCRIPTION
It's now possible for FunctionAssignment to use the new logic in Preprocessor to figure out if the expression it's given
is actually a valid function assignment with a name, parentheses and a list of arguments.