### PR TITLE
feat: Function expression type

### DIFF
--- a/src/main/scala/replcalc/Parser.scala
+++ b/src/main/scala/replcalc/Parser.scala
@@ -34,6 +34,7 @@ object Parser:
       AddSubstract.parse,
       MultiplyDivide.parse,
       UnaryMinus.parse,
+      Function.parse,
       Value.parse,
       Constant.parse
     )

--- a/src/main/scala/replcalc/expressions/Function.scala
+++ b/src/main/scala/replcalc/expressions/Function.scala
@@ -1,0 +1,45 @@
+package replcalc.expressions
+
+import replcalc.{Dictionary, Parser, Preprocessor}
+import replcalc.expressions.Error.{EvaluationError, ParsingError}
+
+final case class Function(name: String, args: Seq[Expression]) extends Expression:
+  override def evaluate(dict: Dictionary): Either[Error, Double] =
+    dict.get(name) match
+      case Some(f: FunctionAssignment) if f.argNames.length == args.length =>
+        val argMap = f.argNames.zip(args).toMap
+        f.evaluate(dict.copy(argMap))
+      case _ =>
+        Left(EvaluationError(s"Function not found: $name"))
+
+object Function extends Parseable[Function]:
+  override def parse(line: String, parser: Parser): ParsedExpr[Function] =
+    Preprocessor.findParens(line, functionParens = true) match
+      case None =>
+        None
+      case Some(Left(error)) =>
+        Some(Left(error))
+      case Some(Right((opening, closing))) =>
+        val name = line.substring(0, opening)
+        if !Dictionary.isValidName(name) then
+          None
+        else if !parser.dictionary.contains(name) then
+          Some(Left(ParsingError(s"Function not found: $name")))
+        else if closing + 1 < line.length then
+          Some(Left(ParsingError(s"Unrecognized chunk of a function expression: ${line.substring(closing + 1)}")))
+        else
+          val args =
+            line
+              .substring(opening + 1, closing)
+              .split(",")
+              .map(arg => arg -> parser.parse(arg))
+              .toSeq
+          val errors = args.collect {
+            case (argName, None)              => s"Unable to parse argument: $argName"
+            case (argName, Some(Left(error))) => s"Error while evaluating argument $argName: ${error.msg}"
+          }
+          if errors.nonEmpty then
+            Some(Left(ParsingError(s"""${errors.mkString("; ")}""")))
+          else
+            val validArgs: Seq[Expression] = args.collect { case (_, Some(Right(expr))) => expr }
+            Some(Right(Function(name, validArgs)))

--- a/src/main/scala/replcalc/expressions/Value.scala
+++ b/src/main/scala/replcalc/expressions/Value.scala
@@ -7,13 +7,13 @@ final case class Value(name: String) extends Expression:
   override def evaluate(dict: Dictionary): Either[Error, Double] =
     dict.get(name) match
       case Some(expr) => expr.evaluate(dict)
-      case None       => Left(EvaluationError(s"Evaluation error: Value not found: $name"))
+      case _          => Left(EvaluationError(s"Value not found: $name"))
   
 object Value extends Parseable[Value]:
   override def parse(line: String, parser: Parser): ParsedExpr[Value] =
     if !Dictionary.isValidName(line, true) then 
       None
     else if !parser.dictionary.contains(line) then
-      Some(Left(ParsingError(s"Parsing error: Value not found: $line")))
+      Some(Left(ParsingError(s"Value not found: $line")))
     else
       Some(Right(Value(line)))

--- a/src/main/scala/replcalc/expressions/ValueAssignment.scala
+++ b/src/main/scala/replcalc/expressions/ValueAssignment.scala
@@ -21,11 +21,11 @@ object ValueAssignment extends Parseable[ValueAssignment]:
       Some(Left(ParsingError(s"The value $name is already defined")))
     else
       parser.parse(exprStr) match
+        case None =>
+          Some(Left(ParsingError(s"Unable to parse: $exprStr")))
+        case Some(Left(error)) =>
+          Some(Left(error))
         case Some(Right(expression)) =>
           val assignment = ValueAssignment(name, expression)
           parser.dictionary.add(name, assignment)
           Some(Right(assignment))
-        case Some(Left(error)) =>
-          Some(Left(error))
-        case None =>
-          Some(Left(ParsingError(s"Unable to parse: $exprStr")))

--- a/src/test/scala/replcalc/ExpressionTest.scala
+++ b/src/test/scala/replcalc/ExpressionTest.scala
@@ -7,26 +7,28 @@ class ExpressionTest extends munit.FunSuite:
 
   private def createParser(dict: Dictionary = Dictionary()): Parser = Parser(dict)
 
-  private def eval(str: String, expected: Double, delta: Double = 0.001)(implicit parser: Parser) =
+  private def eval(str: String, expected: Double, delta: Double = 0.001)(implicit parser: Parser): Unit =
     parser.parse(str) match
-      case None => failComparison("Parsed as 'none'", str, expected)
-      case Some(Left(error)) => failComparison(s"Error: ${error.msg}", str, expected)
+      case None => 
+        failComparison("Parsed as 'none'", str, expected)
+      case Some(Left(error)) => 
+        failComparison(s"Error: ${error.msg}", str, expected)
       case Some(Right(expr)) =>
         expr.evaluate(parser.dictionary) match
           case Right(result) => assertEqualsDouble(result, expected, delta)
           case Left(error)   => failComparison(s"Error: ${error.msg}", str, expected)
 
-  private def parse(str: String)(implicit parser: Parser) =
+  private def parse(str: String)(implicit parser: Parser): Unit =
     parser.parse(str) match
-      case None => fail(s"Parsed as 'none': $str")
+      case None              => fail(s"Parsed as 'none': $str")
       case Some(Left(error)) => fail(s"Error: ${error.msg} at line $str")
       case Some(Right(expr)) =>
 
-  private def shouldReturnParsingError(line: String)(implicit parser: Parser) =
+  private def shouldReturnParsingError(line: String)(implicit parser: Parser): Unit =
     parser.parse(line) match
-      case None => fail(s"Parsed as 'none': $line")
-      case Some(Right(expr)) => fail(s"Parsed with success: $line -> $expr")
+      case None              => fail(s"Parsed as 'none': $line")
       case Some(Left(error)) =>
+      case Some(Right(expr)) => fail(s"Parsed with success: $line -> $expr")
 
   test("Number") {
     implicit def parser: Parser = createParser()
@@ -161,4 +163,41 @@ class ExpressionTest extends munit.FunSuite:
     parse("a = 3")
     parse("myFunc(x) = a + x + 2")
     shouldReturnParsingError("myFunc(x) = y")
+  }
+
+  test("Functions with one argument") {
+    implicit val parser: Parser = createParser()
+    parse("foo(x) = x + 1")
+    eval("foo(1)", 2.0)
+    eval("foo(1) + 1", 3.0)
+    eval("foo(1+2)", 4.0)
+    eval("foo(foo(1))", 3.0)
+    eval("foo(foo(1)+foo(1))", 5.0)
+    parse("bar(x) = x - 1")
+    eval("foo(1)+bar(1)", 2.0)
+    eval("1+foo(2*(1+bar(3)))+bar((foo(4)+5)/2)+2", 14.0)
+  }
+
+  test("Functions with many arguments") {
+    implicit val parser: Parser = createParser()
+    parse("foo(x, y) = x + y")
+    eval("foo(1, 2)", 3.0)
+    eval("foo(foo(1, 2), foo(3, 4))", 10.0)
+    parse("bar(x, y, z) = x + y + z")
+    eval("1 + bar(foo(2, 1), 3, 4 + foo(5, 1))", 17.0)
+  }
+
+  test("Function using previously defined values") {
+    implicit val parser: Parser = createParser()
+    parse("x = 1")
+    parse("foo(y) = x + y")
+    eval("foo(2)", 3.0)
+  }
+
+  test("Function arguments shadowing previously defined values") {
+    implicit val parser: Parser = createParser()
+    parse("x = 1")
+    parse("foo(x) = x + 1")
+    eval("foo(2)", 3.0)
+    eval("x", 1.0)
   }


### PR DESCRIPTION
https://github.com/makingthematrix/replcalc/projects/1#card-74102362

At last!

So I have function assignments already, the preprocessor takes care of the arguments list, and now finally this PR is about evaluating functions in expressions. Answering questions from the GitHub ticket:
1. A function can use previously defined values. If an argument has the same name as the value, it shadows the value, but only within the scope of the function. After the function is evaluated, the next expression will again use the original value.
2. A function is evaluated every time it's called. This will have some effects when I introduce reassignments to previously defined variables (not constant values) which then can be used in evaluating the function. But that's an issue I will tackle in the reassignment PR, not here. For now, since it's not possible to reassign, the result of the function can differ only when the arguments are different. Previously defined values stay the same.
3. A function can't be reassigned.
4. A function can be an argument to another function, no problem here. But it's not possible to create recursion. The function has to be already defined to be used, so a function assignment can't have itself on the right side.