### PR TITLE
refactor: Argument expression type

### DIFF
--- a/src/main/scala/replcalc/expressions/Argument.scala
+++ b/src/main/scala/replcalc/expressions/Argument.scala
@@ -1,0 +1,10 @@
+package replcalc.expressions
+
+import replcalc.Dictionary
+import replcalc.expressions.Error.EvaluationError
+
+final case class Argument(name: String) extends Expression:
+  override def evaluate(dict: Dictionary): Either[Error, Double] =
+    dict.get(name) match
+      case Some(expr) => expr.evaluate(dict)
+      case _          => Left(EvaluationError(s"Value not found for the argument: $name"))

--- a/src/main/scala/replcalc/expressions/FunctionAssignment.scala
+++ b/src/main/scala/replcalc/expressions/FunctionAssignment.scala
@@ -33,7 +33,7 @@ object FunctionAssignment extends Parseable[FunctionAssignment]:
       if errors.nonEmpty then
         Some(Left(ParsingError(s"""Invalid argument(s): ${errors.mkString(", ")}""")))
       else
-        val argsMap = argNames.map(name => name -> Value(name)).toMap
+        val argsMap = argNames.map(name => name -> Argument(name)).toMap
         val innerDict = parser.dictionary.copy(argsMap)
         Parser(innerDict).parse(exprStr) match
           case None =>


### PR DESCRIPTION
https://github.com/makingthematrix/replcalc/projects/1#card-74638105

In my progress I have just hit a problem that I imagine can be quite common for people who write FP compilers.
So far, I didn't let for reassignments. That was useful for a bunch of things. For example, any value of the form `y = x + 1` is evaluated on demand - it's a function with no arguments, in fact. Since `x` can't change, its value, `y` also can't, so it desnn't matter when exactly it's evaluated.
But now I introduce reassignments and it all falls apart 😄
I thought through a few options and finally I decided that if I want reassignment, I need to evaluate variables eagerly. So if `x` is `1` and then I evaluate `y = x + 1`, that means `y` is now `2`, and even if I reassign `x` to `3` in the next line, `y` will stay `2`. But that also means that I need a new type for arguments in functions - they need to stay lazy because when I create a function I don't know their values yet. I only know their names. They should stay in the expression as if they were placeholders and they can be evaluated only when the function is evaluated.

So, here I introduce the new expression type, `Argument`, which is basically the same as `Value` now, but it's only
used by functions. In the next PR I will rewrite `Value` as `Variable` and change its logic so from now on it will be evaluated eagerly and it will be possible to reassign a variable (but not a function).