### PR TITLE
refactor: Cleaner error handling

### DIFF
--- a/src/main/scala/replcalc/Dictionary.scala
+++ b/src/main/scala/replcalc/Dictionary.scala
@@ -7,9 +7,9 @@ final class Dictionary(private var expressions: Map[String, Expression] = Map.em
                        private var specialValuesCounter: Long = 0L):
   def canAssign(name: String): Boolean =
     expressions.get(name) match
-      case Some(_ : Assignment) => true
+      case Some(_ : Assignment)      => true
       case None if isValidName(name) => true
-      case _ => false
+      case _                         => false
   
   def add(name: String, expr: Expression): Boolean =
     expressions.get(name) match
@@ -32,11 +32,7 @@ final class Dictionary(private var expressions: Map[String, Expression] = Map.em
 
   inline def contains(name: String): Boolean = expressions.contains(name)
 
-  inline def listNames(withSpecial: Boolean = false): Set[String] =
-    if withSpecial then
-      expressions.keySet
-    else
-      expressions.keySet.filter(_.head != '$')
+  inline def listNames: Set[String] = expressions.keySet.filter(_.head != '$')
 
   def copy(updates: Map[String, Expression]): Dictionary = 
     Dictionary(expressions ++ updates, specialValuesCounter)

--- a/src/main/scala/replcalc/Main.scala
+++ b/src/main/scala/replcalc/Main.scala
@@ -22,7 +22,7 @@ def main(args: String*): Unit =
 
 private def listValues(dict: Dictionary): Unit =
   dict
-    .listNames().toSeq.sorted
+    .listNames.toSeq.sorted
     .map(name => dict.get(name))
     .collect { case Some(expr) => replForm(expr, dict) }
     .foreach(println)

--- a/src/main/scala/replcalc/Parser.scala
+++ b/src/main/scala/replcalc/Parser.scala
@@ -36,5 +36,6 @@ object Parser:
       UnaryMinus.parse,
       Function.parse,
       Variable.parse,
-      Constant.parse
+      Constant.parse,
+      Failure.parse
     )

--- a/src/main/scala/replcalc/expressions/AddSubstract.scala
+++ b/src/main/scala/replcalc/expressions/AddSubstract.scala
@@ -3,6 +3,7 @@ package replcalc.expressions
 import scala.annotation.tailrec
 import Error.ParsingError
 import replcalc.{Dictionary, Parser}
+import replcalc.Parser.isOperator
 
 final case class AddSubstract(left: Expression, right: Expression, isSubstraction: Boolean = false) extends Expression:
   override def evaluate(dict: Dictionary): Either[Error, Double] =
@@ -14,24 +15,26 @@ final case class AddSubstract(left: Expression, right: Expression, isSubstractio
 
 object AddSubstract extends Parseable[AddSubstract]:
   override def parse(line: String, parser: Parser): ParsedExpr[AddSubstract] =
-    val plusIndex = line.lastIndexOf("+")
+    val plusIndex  = line.lastIndexOf("+")
     val minusIndex = lastBinaryMinus(line)
     val (index, isSubstraction) = if plusIndex > minusIndex then (plusIndex, false) else (minusIndex, true)
-    if index > 0 && index < line.length - 1 then
-      (for
-        lExpr <- parser.parse(line.substring(0, index))
-        rExpr <- if (lExpr.isRight) parser.parse(line.substring(index + 1)) else Some(Left(Error.Unused))
-      yield (lExpr, rExpr)).map {
-        case (Right(l), Right(r)) => Right(AddSubstract(l, r, isSubstraction))
+    if index <= 0 || index >= line.length - 1 then
+      ParsedExpr.empty
+    else
+      val innerExpressions =
+        for
+          lExpr <- parser.parse(line.substring(0, index))
+          rExpr <- if (lExpr.isRight) parser.parse(line.substring(index + 1)) else ParsedExpr.unused
+        yield (lExpr, rExpr)
+      innerExpressions.map {
         case (Left(error), _)     => Left(error)
         case (_, Left(error))     => Left(error)
+        case (Right(l), Right(r)) => Right(AddSubstract(l, r, isSubstraction))
       }
-    else
-      None
-
+    
   @tailrec
   private def lastBinaryMinus(line: String): Int =
     line.lastIndexOf("-") match
-      case index if index <= 0                                 => -1
-      case index if !Parser.isOperator(line.charAt(index - 1)) => index
-      case index                                               => lastBinaryMinus(line.substring(0, index))
+      case index if index <= 0                          => -1
+      case index if !isOperator(line.charAt(index - 1)) => index
+      case index                                        => lastBinaryMinus(line.substring(0, index))

--- a/src/main/scala/replcalc/expressions/Constant.scala
+++ b/src/main/scala/replcalc/expressions/Constant.scala
@@ -8,6 +8,6 @@ final case class Constant(number: Double) extends Expression:
 
 object Constant extends Parseable[Constant]:
   override def parse(line: String, parser: Parser): ParsedExpr[Constant] =
-    line.toDoubleOption match
-      case Some(d) => Some(Right(Constant(d)))
-      case None    => Some(Left(ParsingError(s"Unable to parse: $line")))
+    line
+      .toDoubleOption
+      .map(number => Right(Constant(number)))

--- a/src/main/scala/replcalc/expressions/Error.scala
+++ b/src/main/scala/replcalc/expressions/Error.scala
@@ -4,6 +4,3 @@ enum Error(val msg: String):
   case ParsingError(override val msg: String) extends Error(msg)
   case EvaluationError(override val msg: String) extends Error(msg)
   case PreprocessorError(override val msg: String) extends Error(msg)
-
-object Error:
-  val Unused: ParsingError = ParsingError("Unused expr")

--- a/src/main/scala/replcalc/expressions/Expression.scala
+++ b/src/main/scala/replcalc/expressions/Expression.scala
@@ -3,8 +3,6 @@ package replcalc.expressions
 import replcalc.{Dictionary, Parser}
 import replcalc.expressions.Error
 
-type ParsedExpr[T] = Option[Either[Error, T]]
-
 trait Parseable[T <: Expression]:
   def parse(line: String, parser: Parser): ParsedExpr[T]
 

--- a/src/main/scala/replcalc/expressions/Failure.scala
+++ b/src/main/scala/replcalc/expressions/Failure.scala
@@ -1,0 +1,8 @@
+package replcalc.expressions
+
+import replcalc.Parser
+
+object Failure extends Parseable[Expression]:
+  override def parse(line: String, parser: Parser): ParsedExpr[Expression] = 
+    ParsedExpr.error(s"Unable to parse: $line")
+

--- a/src/main/scala/replcalc/expressions/FunctionAssignment.scala
+++ b/src/main/scala/replcalc/expressions/FunctionAssignment.scala
@@ -14,38 +14,35 @@ object FunctionAssignment extends Parseable[FunctionAssignment]:
     else
       val assignIndex = line.indexOf('=')
       val assignmentStr = line.substring(0, assignIndex)
-      Preprocessor.findParens(assignmentStr, functionParens = true).map {
+      Preprocessor.findParens(assignmentStr, functionParens = true).flatMap {
         case Left(error) =>
-          Left(error)
+          ParsedExpr.error(error)
         case Right((opening, closing)) =>
           val functionName  = assignmentStr.substring(0, opening)
           val arguments     = assignmentStr.substring(opening + 1, closing)
           val expressionStr = line.substring(assignIndex + 1)
-          parseFunctionAssignment(functionName, arguments, expressionStr, parser)
+          parseAssignment(functionName, arguments, expressionStr, parser)
       }
 
-  private def parseFunctionAssignment(functionName: String, arguments: String, expressionStr: String, parser: Parser): Either[Error, FunctionAssignment] =
+  private def parseAssignment(functionName: String, arguments: String, expressionStr: String, parser: Parser): ParsedExpr[FunctionAssignment] =
     if !Dictionary.isValidName(functionName) then
-      Left(ParsingError(s"Invalid function name: $functionName"))
+      ParsedExpr.error(s"Invalid function name: $functionName")
     else if parser.dictionary.contains(functionName) then
-      Left(ParsingError(s"The function already exists: $functionName"))
+      ParsedExpr.error(s"The function already exists: $functionName")
     else
       val argNames = arguments.split(",").map(_.trim).filter(_.nonEmpty).toSeq
-      val errors = argNames.collect { case argName if !Dictionary.isValidName(argName) => argName }
+      val errors   = argNames.collect { case argName if !Dictionary.isValidName(argName) => argName }
       if errors.nonEmpty then
-        Left(ParsingError(s"""Invalid argument(s): ${errors.mkString(", ")}"""))
+        ParsedExpr.error(s"""Invalid argument(s): ${errors.mkString(", ")}""")
       else
-        val argsMap = argNames.map(name => name -> Variable(name)).toMap
+        val argsMap   = argNames.map(name => name -> Variable(name)).toMap
         val innerDict = parser.dictionary.copy(argsMap)
         Parser(innerDict)
           .parse(expressionStr)
-          .map {
-            case Left(error) =>
-              Left(error)
-            case Right(expression) =>
-              FunctionAssignment(functionName, argNames, expression).pipe { assignment =>
-                parser.dictionary.add(functionName, assignment)
-                Right(assignment)
-              }
+          .happyPath { expression =>
+            FunctionAssignment(functionName, argNames, expression).pipe { assignment =>
+              parser.dictionary.add(functionName, assignment)
+              ParsedExpr(assignment)
+            }
           }
-          .getOrElse(Left(ParsingError(s"Unable to parse: $expressionStr")))
+          .errorIfEmpty(s"Unable to parse: $expressionStr")

--- a/src/main/scala/replcalc/expressions/MultiplyDivide.scala
+++ b/src/main/scala/replcalc/expressions/MultiplyDivide.scala
@@ -5,10 +5,12 @@ import replcalc.{Dictionary, Parser}
 
 final case class MultiplyDivide(left: Expression, right: Expression, isDivision: Boolean = false) extends Expression:
   override def evaluate(dict: Dictionary): Either[Error, Double] =
-    (for
-      lResult <- left.evaluate(dict)
-      rResult <- right.evaluate(dict)
-    yield (lResult, rResult)).flatMap {
+    val innerResults =
+      for
+        lResult <- left.evaluate(dict)
+        rResult <- right.evaluate(dict)
+      yield (lResult, rResult)
+    innerResults.flatMap {
       case (l, r) if isDivision && r == 0.0 => Left(EvaluationError(s"Division by zero: $l / $r"))
       case (l, r) if isDivision             => Right(l / r)
       case (l, r)                           => Right(l * r)
@@ -19,14 +21,16 @@ object MultiplyDivide extends Parseable[MultiplyDivide]:
     val mulIndex = line.lastIndexOf("*")
     val divIndex = line.lastIndexOf("/")
     val (index, isDivision) = if mulIndex > divIndex then (mulIndex, false) else (divIndex, true)
-    if index > 0 && index < line.length - 1 then
-      (for
-        lExpr <- parser.parse(line.substring(0, index))
-        rExpr <- if (lExpr.isRight) parser.parse(line.substring(index + 1)) else Some(Left(Error.Unused))
-      yield (lExpr, rExpr)).map {
-        case (Right(l), Right(r)) => Right(MultiplyDivide(l, r, isDivision))
+    if index <= 0 || index >= line.length - 1 then
+      ParsedExpr.empty
+    else
+      val innerExpressions =
+        for
+          lExpr <- parser.parse(line.substring(0, index))
+          rExpr <- if (lExpr.isRight) parser.parse(line.substring(index + 1)) else ParsedExpr.unused
+        yield (lExpr, rExpr)
+      innerExpressions.map {
         case (Left(error), _)     => Left(error)
         case (_, Left(error))     => Left(error)
+        case (Right(l), Right(r)) => Right(MultiplyDivide(l, r, isDivision))
       }
-    else
-      None

--- a/src/main/scala/replcalc/expressions/ParsedExpr.scala
+++ b/src/main/scala/replcalc/expressions/ParsedExpr.scala
@@ -1,0 +1,24 @@
+package replcalc.expressions
+
+import Error.ParsingError
+
+type ParsedExpr[T <: Expression] = Option[Either[Error, T]]
+
+extension [T <: Expression] (parsedExpr: ParsedExpr[T]) {
+  def happyPath[S <: Expression](f: T => ParsedExpr[S]): ParsedExpr[S] =
+    parsedExpr.flatMap {
+      case Left(error)       => ParsedExpr.error(error)
+      case Right(expression) => f(expression)
+    }
+
+  def errorIfEmpty(error: Error): ParsedExpr[T] = parsedExpr.orElse(ParsedExpr.error(error))
+  def errorIfEmpty(errorMsg: String): ParsedExpr[T] = parsedExpr.orElse(ParsedExpr.error(errorMsg))
+}
+
+object ParsedExpr {
+  def apply[T <: Expression](expr: T): ParsedExpr[T] = Some(Right(expr))
+  def error[T <: Expression](error: Error): ParsedExpr[T] = Some(Left(error))
+  def error[T <: Expression](errorMsg: String): ParsedExpr[T] = Some(Left(ParsingError(errorMsg)))
+  def empty[T <: Expression]: ParsedExpr[T] = Option.empty[Either[Error, T]]
+  def unused[T <: Expression]: ParsedExpr[T] = Some(Left(ParsingError("Unused expression")))
+}

--- a/src/main/scala/replcalc/expressions/UnaryMinus.scala
+++ b/src/main/scala/replcalc/expressions/UnaryMinus.scala
@@ -1,14 +1,16 @@
 package replcalc.expressions
 
 import Error.ParsingError
-import replcalc.{Dictionary, Parser}
+import replcalc.{Dictionary, Parser, expressions}
 
 final case class UnaryMinus(innerExpr: Expression) extends Expression:
   override def evaluate(dict: Dictionary): Either[Error, Double] = innerExpr.evaluate(dict).map(-_)
   
 object UnaryMinus extends Parseable[UnaryMinus]:
   override def parse(line: String, parser: Parser): ParsedExpr[UnaryMinus] =
-    if line.length > 1 && line.head == '-' then
-      parser.parse(line.substring(1)).map(_.map(UnaryMinus.apply))
-    else 
-      None
+    if line.length <= 1 || line.head != '-' then
+      ParsedExpr.empty
+    else
+      parser
+        .parse(line.substring(1))
+        .happyPath(expr => ParsedExpr(UnaryMinus(expr)))

--- a/src/main/scala/replcalc/expressions/Variable.scala
+++ b/src/main/scala/replcalc/expressions/Variable.scala
@@ -5,15 +5,15 @@ import replcalc.{Dictionary, Parser}
 
 final case class Variable(name: String) extends Expression:
   override def evaluate(dict: Dictionary): Either[Error, Double] =
-    dict.get(name) match
-      case Some(expr) => expr.evaluate(dict)
-      case _          => Left(EvaluationError(s"Variable not found: $name"))
+    dict.get(name)
+      .map(_.evaluate(dict))
+      .getOrElse(Left(EvaluationError(s"Variable not found: $name")))
   
 object Variable extends Parseable[Variable]:
   override def parse(line: String, parser: Parser): ParsedExpr[Variable] =
     if !Dictionary.isValidName(line, true) then 
-      None
+      ParsedExpr.empty
     else if !parser.dictionary.contains(line) then
-      Some(Left(ParsingError(s"Variable not found: $line")))
+      ParsedExpr.error(s"Variable not found: $line")
     else
-      Some(Right(Variable(line)))
+      ParsedExpr(Variable(line))

--- a/src/test/scala/replcalc/DictionaryTest.scala
+++ b/src/test/scala/replcalc/DictionaryTest.scala
@@ -23,7 +23,7 @@ class DictionaryTest extends munit.FunSuite:
     val dict = Dictionary()
     dict.add("a", Constant(1.0))
     dict.add("b", Constant(2.0))
-    assertEquals(dict.listNames(), Set("a", "b"))
+    assertEquals(dict.listNames, Set("a", "b"))
   }
 
   test("Handle an attempt to get an unassigned expression") {


### PR DESCRIPTION
So far error handling was done "by hand", so to say. There is a lot of places in the code where I parse or evaluate an expression and need to handle different outcomes. The result of parsing might be that the parsed expression is not of the type I assumed - which is not exactly an error, I just need to try with another expression type. But it also might be of the given type but it's incorrect - then it's really an error. Or, at last, it can be a valid expression of the given type and then I need to handle the parsed entity in a certain one.

Until now all those cases were handled next to each other which made the code less readable than it could be. This PR tries to move handling of errors and the "not this type" answer to the side and focus more on the "happy path" when there is a valid expression. I tried a few solutions and in the end decided on sticking to `type ParsedExpr[T] = Option[Either[Error, T]]` where `T` is an expression type, but I introduced a few utility methods that take care of cases where I get `None` or `Some(Left(error))` as results of parsing.

The final goal is readability.