### PR TITLE
refactor: Code beautification

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ Test / parallelExecution := true
 Test / fork := true
 
 developers := List(
-  Developer("makingthematrix", "Maciej Gorywoda", "maciej.gorywoda@wire.com", url("https://github.com/makingthematrix"))
+  Developer("makingthematrix", "Maciej Gorywoda", "makingthematrix@protonmail.com", url("https://github.com/makingthematrix"))
 )
 
 licenses := Seq("GPL 3.0" -> url("https://www.gnu.org/licenses/gpl-3.0.en.html"))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.5.5
+sbt.version = 1.5.7

--- a/src/main/scala/replcalc/Dictionary.scala
+++ b/src/main/scala/replcalc/Dictionary.scala
@@ -32,7 +32,9 @@ final class Dictionary(private var expressions: Map[String, Expression] = Map.em
 
   inline def contains(name: String): Boolean = expressions.contains(name)
 
-  inline def listNames: Set[String] = expressions.keySet.filter(_.head != '$')
+  inline def names: Set[String] = expressions.keySet.filter(_.head != '$')
+
+  inline def allExpressions: Seq[Expression] = expressions.filter(_._1.head != '$').toSeq.sortBy(_._1).map(_._2)
 
   def copy(updates: Map[String, Expression]): Dictionary = 
     Dictionary(expressions ++ updates, specialValuesCounter)

--- a/src/main/scala/replcalc/Parser.scala
+++ b/src/main/scala/replcalc/Parser.scala
@@ -3,23 +3,20 @@ package replcalc
 import replcalc.Preprocessor.Flags
 import replcalc.expressions.*
 
-final class Parser(private val dict: Dictionary = Dictionary(), preprocessorFlags: Flags = Flags.AllTrue):
+final class Parser(val dictionary: Dictionary = Dictionary(), preprocessorFlags: Flags = Flags.AllFlagsOn):
   self =>
   import Parser.*
 
-  private lazy val pre = Preprocessor(this, preprocessorFlags)
-  
-  def dictionary: Dictionary = dict
-  def preprocessor: Preprocessor = pre 
+  lazy val preprocessor: Preprocessor = Preprocessor(this, preprocessorFlags)
 
   def parse(line: String): ParsedExpr[Expression] =
-    pre.process(line) match
+    preprocessor.process(line) match
       case Left(error) =>
         Some(Left(error))
       case Right(processed) =>
         // about early returns in Scala: https://makingthematrix.wordpress.com/2021/03/09/many-happy-early-returns/
         object Parsed:
-          def unapply(stage: (String, Parser) => ParsedExpr[Expression]): ParsedExpr[Expression] = stage(processed, self)
+          def unapply(stage: (Parser, String) => ParsedExpr[Expression]): ParsedExpr[Expression] = stage(self, processed)
         stages.collectFirst { case Parsed(expr) => expr }
 
 object Parser:
@@ -27,7 +24,7 @@ object Parser:
 
   private val operators: Set[Char] = Set('+', '-', '*', '/', ',')
 
-  private val stages: Seq[(String, Parser) => ParsedExpr[Expression]] =
+  private val stages: Seq[(Parser, String) => ParsedExpr[Expression]] =
     Seq(
       FunctionAssignment.parse,
       Assignment.parse,

--- a/src/main/scala/replcalc/expressions/AddSubstract.scala
+++ b/src/main/scala/replcalc/expressions/AddSubstract.scala
@@ -8,13 +8,16 @@ import replcalc.Parser.isOperator
 final case class AddSubstract(left: Expression, right: Expression, isSubstraction: Boolean = false) extends Expression:
   override def evaluate(dict: Dictionary): Either[Error, Double] =
     for
-      l <- left.evaluate(dict)
-      r <- right.evaluate(dict)
+      lResult <- left.evaluate(dict)
+      rResult <- right.evaluate(dict)
     yield
-      if isSubstraction then l - r else l + r
+      if isSubstraction then 
+        lResult - rResult 
+      else 
+        lResult + rResult
 
 object AddSubstract extends Parseable[AddSubstract]:
-  override def parse(line: String, parser: Parser): ParsedExpr[AddSubstract] =
+  override def parse(parser: Parser, line: String): ParsedExpr[AddSubstract] =
     val plusIndex  = line.lastIndexOf("+")
     val minusIndex = lastBinaryMinus(line)
     val (index, isSubstraction) = if plusIndex > minusIndex then (plusIndex, false) else (minusIndex, true)

--- a/src/main/scala/replcalc/expressions/Assignment.scala
+++ b/src/main/scala/replcalc/expressions/Assignment.scala
@@ -5,17 +5,17 @@ import replcalc.{Dictionary, Parser}
 import scala.util.chaining.*
 
 final case class Assignment(name: String, constant: Constant) extends Expression:
-  override def evaluate(dict: Dictionary): Either[Error, Double] = Right(constant.number)
+  override def evaluate(dict: Dictionary): Either[Error, Double] = constant.evaluate(dict)
 
 object Assignment extends Parseable[Assignment]:
-  override def parse(line: String, parser: Parser): ParsedExpr[Assignment] =
+  override def parse(parser: Parser, line: String): ParsedExpr[Assignment] =
     if !line.contains("=") then
       ParsedExpr.empty
     else
       val assignIndex = line.indexOf('=')
-      parseAssignment(line.substring(0, assignIndex), line.substring(assignIndex + 1), parser)
+      parseAssignment(parser, line.substring(0, assignIndex), line.substring(assignIndex + 1))
 
-  private def parseAssignment(name: String, expressionStr: String, parser: Parser): ParsedExpr[Assignment] =
+  private def parseAssignment(parser: Parser, name: String, expressionStr: String): ParsedExpr[Assignment] =
     if !Dictionary.isValidName(name) then
       ParsedExpr.error(s"Invalid variable name: $name")
     else if !parser.dictionary.canAssign(name) then
@@ -23,11 +23,9 @@ object Assignment extends Parseable[Assignment]:
     else
       parser
         .parse(expressionStr)
-        .happyPath { expression =>
-          expression
-            .evaluate(parser.dictionary).map { number =>
-              Assignment(name, Constant(number)).tap { parser.dictionary.add(name, _) }
-            }
-            .pipe(Some(_))
+        .happyPath {
+          _.evaluate(parser.dictionary).map { number =>
+            Assignment(name, Constant(number)).tap(parser.dictionary.add(name, _))
+          }.pipe(Some(_))
         }
         .errorIfEmpty(s"Unable to parse: $expressionStr")

--- a/src/main/scala/replcalc/expressions/Constant.scala
+++ b/src/main/scala/replcalc/expressions/Constant.scala
@@ -7,7 +7,7 @@ final case class Constant(number: Double) extends Expression:
   override def evaluate(dict: Dictionary): Either[Error, Double] = Right(number)
 
 object Constant extends Parseable[Constant]:
-  override def parse(line: String, parser: Parser): ParsedExpr[Constant] =
+  override def parse(parser: Parser, line: String): ParsedExpr[Constant] =
     line
       .toDoubleOption
       .map(number => Right(Constant(number)))

--- a/src/main/scala/replcalc/expressions/Expression.scala
+++ b/src/main/scala/replcalc/expressions/Expression.scala
@@ -4,7 +4,7 @@ import replcalc.{Dictionary, Parser}
 import replcalc.expressions.Error
 
 trait Parseable[T <: Expression]:
-  def parse(line: String, parser: Parser): ParsedExpr[T]
+  def parse(parser: Parser, line: String): ParsedExpr[T]
 
 trait Expression:
   def evaluate(dict: Dictionary): Either[Error, Double]

--- a/src/main/scala/replcalc/expressions/Failure.scala
+++ b/src/main/scala/replcalc/expressions/Failure.scala
@@ -3,6 +3,6 @@ package replcalc.expressions
 import replcalc.Parser
 
 object Failure extends Parseable[Expression]:
-  override def parse(line: String, parser: Parser): ParsedExpr[Expression] = 
+  override def parse(parser: Parser, line: String): ParsedExpr[Expression] = 
     ParsedExpr.error(s"Unable to parse: $line")
 

--- a/src/main/scala/replcalc/expressions/Function.scala
+++ b/src/main/scala/replcalc/expressions/Function.scala
@@ -13,7 +13,7 @@ final case class Function(name: String, args: Seq[Expression]) extends Expressio
         Left(EvaluationError(s"Function not found: $name"))
 
 object Function extends Parseable[Function]:
-  override def parse(line: String, parser: Parser): ParsedExpr[Function] =
+  override def parse(parser: Parser, line: String): ParsedExpr[Function] =
     Preprocessor.findParens(line, functionParens = true).flatMap {
       case Left(error) =>
         ParsedExpr.error(error)

--- a/src/main/scala/replcalc/expressions/MultiplyDivide.scala
+++ b/src/main/scala/replcalc/expressions/MultiplyDivide.scala
@@ -17,7 +17,7 @@ final case class MultiplyDivide(left: Expression, right: Expression, isDivision:
     }
 
 object MultiplyDivide extends Parseable[MultiplyDivide]:
-  override def parse(line: String, parser: Parser): ParsedExpr[MultiplyDivide] =
+  override def parse(parser: Parser, line: String): ParsedExpr[MultiplyDivide] =
     val mulIndex = line.lastIndexOf("*")
     val divIndex = line.lastIndexOf("/")
     val (index, isDivision) = if mulIndex > divIndex then (mulIndex, false) else (divIndex, true)
@@ -27,7 +27,7 @@ object MultiplyDivide extends Parseable[MultiplyDivide]:
       val innerExpressions =
         for
           lExpr <- parser.parse(line.substring(0, index))
-          rExpr <- if (lExpr.isRight) parser.parse(line.substring(index + 1)) else ParsedExpr.unused
+          rExpr <- if lExpr.isRight then parser.parse(line.substring(index + 1)) else ParsedExpr.unused
         yield (lExpr, rExpr)
       innerExpressions.map {
         case (Left(error), _)     => Left(error)

--- a/src/main/scala/replcalc/expressions/UnaryMinus.scala
+++ b/src/main/scala/replcalc/expressions/UnaryMinus.scala
@@ -7,7 +7,7 @@ final case class UnaryMinus(innerExpr: Expression) extends Expression:
   override def evaluate(dict: Dictionary): Either[Error, Double] = innerExpr.evaluate(dict).map(-_)
   
 object UnaryMinus extends Parseable[UnaryMinus]:
-  override def parse(line: String, parser: Parser): ParsedExpr[UnaryMinus] =
+  override def parse(parser: Parser, line: String): ParsedExpr[UnaryMinus] =
     if line.length <= 1 || line.head != '-' then
       ParsedExpr.empty
     else

--- a/src/main/scala/replcalc/expressions/Variable.scala
+++ b/src/main/scala/replcalc/expressions/Variable.scala
@@ -5,12 +5,13 @@ import replcalc.{Dictionary, Parser}
 
 final case class Variable(name: String) extends Expression:
   override def evaluate(dict: Dictionary): Either[Error, Double] =
-    dict.get(name)
+    dict
+      .get(name)
       .map(_.evaluate(dict))
       .getOrElse(Left(EvaluationError(s"Variable not found: $name")))
   
 object Variable extends Parseable[Variable]:
-  override def parse(line: String, parser: Parser): ParsedExpr[Variable] =
+  override def parse(parser: Parser, line: String): ParsedExpr[Variable] =
     if !Dictionary.isValidName(line, true) then 
       ParsedExpr.empty
     else if !parser.dictionary.contains(line) then

--- a/src/test/scala/replcalc/DictionaryTest.scala
+++ b/src/test/scala/replcalc/DictionaryTest.scala
@@ -23,7 +23,7 @@ class DictionaryTest extends munit.FunSuite:
     val dict = Dictionary()
     dict.add("a", Constant(1.0))
     dict.add("b", Constant(2.0))
-    assertEquals(dict.listNames, Set("a", "b"))
+    assertEquals(dict.names, Set("a", "b"))
   }
 
   test("Handle an attempt to get an unassigned expression") {


### PR DESCRIPTION
A bunch of cosmetic changes and small simplifications. Logic entities (the parser and the dictionary) passed around in arguments were moved to first places in the arguments lists. Some logic was moved around to make code more readable. Variable names were standarized (although I still use interchangeably `dict` and `dictionary`, and `expr` and `expression`. `if / then / else` was changed to `match / case` in a few places.