### PR TITLE
fix: Fail on invalid characters right after the function assignment

### DIFF
--- a/src/main/scala/replcalc/expressions/Function.scala
+++ b/src/main/scala/replcalc/expressions/Function.scala
@@ -17,14 +17,14 @@ object Function extends Parseable[Function]:
     Preprocessor.findParens(line, functionParens = true).flatMap {
       case Left(error) =>
         ParsedExpr.error(error)
+      case Right((_, closing)) if closing + 1 < line.length =>
+        ParsedExpr.error(s"Unrecognized chunk of a function expression: ${line.substring(closing + 1)}")
       case Right((opening, closing)) =>
         val name = line.substring(0, opening)
         if !Dictionary.isValidName(name) then
           ParsedExpr.empty
         else if !parser.dictionary.contains(name) then
           ParsedExpr.error(s"Function not found: $name")
-        else if closing + 1 < line.length then
-          ParsedExpr.error(s"Unrecognized chunk of a function expression: ${line.substring(closing + 1)}")
         else
           val args =
             line

--- a/src/main/scala/replcalc/expressions/FunctionAssignment.scala
+++ b/src/main/scala/replcalc/expressions/FunctionAssignment.scala
@@ -17,6 +17,8 @@ object FunctionAssignment extends Parseable[FunctionAssignment]:
       Preprocessor.findParens(assignmentStr, functionParens = true).flatMap {
         case Left(error) =>
           ParsedExpr.error(error)
+        case Right((_, closing)) if closing + 1 < assignmentStr.length =>
+          ParsedExpr.error(s"Unrecognized chunk of a function expression: ${line.substring(closing + 1)}")
         case Right((opening, closing)) =>
           val functionName  = assignmentStr.substring(0, opening)
           val arguments     = assignmentStr.substring(opening + 1, closing)

--- a/src/test/scala/replcalc/ExpressionTest.scala
+++ b/src/test/scala/replcalc/ExpressionTest.scala
@@ -164,6 +164,7 @@ class ExpressionTest extends munit.FunSuite:
     parse("a = 3")
     parse("myFunc(x) = a + x + 2")
     shouldReturnParsingError("myFunc(x) = y")
+    shouldReturnParsingError("baz(x)blabla = x")
   }
 
   test("Functions with one argument") {


### PR DESCRIPTION
So far assignments of the form `foo(x)blahblah = x`, where there are some invalid characters after the closing parentheses, is parsed correctly - those characters are being ignored. It's better if the program fails on this error.