### PR TITLE
refactor: Decouple Preprocessor

### DIFF
--- a/src/main/scala/replcalc/Main.scala
+++ b/src/main/scala/replcalc/Main.scala
@@ -1,7 +1,7 @@
 package replcalc
 
 import replcalc.expressions.{Constant, Expression, FunctionAssignment, Assignment}
-
+import scala.util.chaining.*
 import scala.io.StdIn.readLine
 
 @main
@@ -11,12 +11,9 @@ def main(args: String*): Unit =
   while !exit do
     print("> ")
     readLine().trim match
-      case ":exit" =>
-        exit = true
-      case ":list" =>
-        list(parser.dictionary)
-      case line =>
-        evaluate(parser, line).foreach(println)
+      case ":exit" => exit = true
+      case ":list" => list(parser.dictionary)
+      case line    => evaluate(parser, line).foreach(println)
 
 private def list(dictionary: Dictionary): Unit =
   dictionary

--- a/src/main/scala/replcalc/Preprocessor.scala
+++ b/src/main/scala/replcalc/Preprocessor.scala
@@ -7,7 +7,8 @@ import replcalc.Parser.isOperator
 
 import scala.annotation.tailrec
 
-final class Preprocessor(parser: Parser, flags: Flags = Flags.AllFlagsOn):
+final class Preprocessor(parser: Parser,
+                         flags: Flags = Flags.AllFlagsOn):
   import Preprocessor.*
   
   def process(line: String): Either[Error, String] =

--- a/src/main/scala/replcalc/expressions/Function.scala
+++ b/src/main/scala/replcalc/expressions/Function.scala
@@ -20,25 +20,25 @@ object Function extends Parseable[Function]:
       case Right((_, closing)) if closing + 1 < line.length =>
         ParsedExpr.error(s"Unrecognized chunk of a function expression: ${line.substring(closing + 1)}")
       case Right((opening, closing)) =>
-        val name         = line.substring(0, opening)
-        val argumentsStr = line.substring(opening + 1, closing)
-        parseFunction(parser, name, argumentsStr)
+        val name      = line.substring(0, opening)
+        val arguments = line.substring(opening + 1, closing)
+        parseFunction(parser, name, arguments)
     }
 
-  private def parseFunction(parser: Parser, name: String, argumentsStr: String): ParsedExpr[Function] =
+  private def parseFunction(parser: Parser, name: String, arguments: String): ParsedExpr[Function] =
     if !Dictionary.isValidName(name) then
       ParsedExpr.empty
     else if !parser.dictionary.contains(name) then
       ParsedExpr.error(s"Function not found: $name")
     else
       val args =
-        argumentsStr
+        arguments
           .split(",")
           .collect { case arg if arg.nonEmpty => arg -> parser.parse(arg) }
           .toSeq
       val errors = args.collect {
         case (argName, None)              => s"Unable to parse argument: $argName"
-        case (argName, Some(Left(error))) => s"Error while evaluating argument $argName: ${error.msg}"
+        case (argName, Some(Left(error))) => s"Error while parsing argument $argName: ${error.msg}"
       }
       if errors.nonEmpty then
         ParsedExpr.error(errors.mkString("; "))

--- a/src/main/scala/replcalc/expressions/FunctionAssignment.scala
+++ b/src/main/scala/replcalc/expressions/FunctionAssignment.scala
@@ -37,9 +37,9 @@ object FunctionAssignment extends Parseable[FunctionAssignment]:
       if errors.nonEmpty then
         ParsedExpr.error(s"Invalid argument(s): ${errors.mkString(", ")}")
       else
-        val argsMap   = argNames.map(name => name -> Variable(name)).toMap
-        val innerDict = parser.dictionary.copy(argsMap)
-        Parser(innerDict)
+        val argsMap = argNames.map(name => name -> Variable(name)).toMap
+        parser
+          .copy(argsMap)
           .parse(expressionStr)
           .happyPath { expression =>
             FunctionAssignment(functionName, argNames, expression).pipe { assignment =>


### PR DESCRIPTION
Not much value in this PR except maybe for easier creation of a preprocessor for preprocessor unit tests. The real reason to do it was that I see the preprocessor and the parser as equal components talking to each other, while so far the parser owned the preprocessor. Now they can be created separately, even though they still need each other to work.