### PR TITLE
fix: Don't allow empty arguments

### DIFF
--- a/src/main/scala/replcalc/Main.scala
+++ b/src/main/scala/replcalc/Main.scala
@@ -11,9 +11,10 @@ def main(args: String*): Unit =
   while !exit do
     print("> ")
     readLine().trim match
-      case ":exit" => exit = true
-      case ":list" => list(parser.dictionary)
-      case line    => evaluate(parser, line).foreach(println)
+      case ":exit"              => exit = true
+      case ":list"              => list(parser.dictionary)
+      case line if line.isEmpty =>
+      case line                 => evaluate(parser, line).foreach(println)
 
 private def list(dictionary: Dictionary): Unit =
   dictionary

--- a/src/main/scala/replcalc/expressions/Function.scala
+++ b/src/main/scala/replcalc/expressions/Function.scala
@@ -32,13 +32,14 @@ object Function extends Parseable[Function]:
       ParsedExpr.error(s"Function not found: $name")
     else
       val args =
-        arguments
-          .split(",")
-          .collect { case arg if arg.nonEmpty => arg -> parser.parse(arg) }
-          .toSeq
+        if arguments.nonEmpty then
+          arguments.split(",").map { arg => arg -> parser.parse(arg) }.toSeq
+        else
+          Seq.empty
       val errors = args.collect {
-        case (argName, None)              => s"Unable to parse argument: $argName"
-        case (argName, Some(Left(error))) => s"Error while parsing argument $argName: ${error.msg}"
+        case (argName, _) if argName.isEmpty => "Empty argument"
+        case (argName, None)                 => s"Unable to parse argument: $argName"
+        case (argName, Some(Left(error)))    => s"Error while parsing argument $argName: ${error.msg}"
       }
       if errors.nonEmpty then
         ParsedExpr.error(errors.mkString("; "))

--- a/src/main/scala/replcalc/expressions/FunctionAssignment.scala
+++ b/src/main/scala/replcalc/expressions/FunctionAssignment.scala
@@ -32,8 +32,15 @@ object FunctionAssignment extends Parseable[FunctionAssignment]:
     else if parser.dictionary.contains(functionName) then
       ParsedExpr.error(s"The function already exists: $functionName")
     else
-      val argNames = arguments.split(",").map(_.trim).filter(_.nonEmpty).toSeq
-      val errors   = argNames.collect { case argName if !Dictionary.isValidName(argName) => argName }
+      val argNames =
+        if arguments.nonEmpty then
+          arguments.split(",").map(_.trim).toSeq
+        else
+          Seq.empty
+      val errors = argNames.collect {
+        case argName if argName.isEmpty => "Empty argument name"
+        case argName if !Dictionary.isValidName(argName) => argName
+      }
       if errors.nonEmpty then
         ParsedExpr.error(s"Invalid argument(s): ${errors.mkString(", ")}")
       else

--- a/src/test/scala/replcalc/ExpressionTest.scala
+++ b/src/test/scala/replcalc/ExpressionTest.scala
@@ -152,6 +152,7 @@ class ExpressionTest extends munit.FunSuite:
     parse("myFunc(x) = a + x + 2")
     shouldReturnParsingError("myFunc(x) = y")
     shouldReturnParsingError("baz(x)blabla = x")
+    shouldReturnParsingError("boo(x,,y) = x + y")
   }
 
   test("Functions with one argument") {
@@ -174,6 +175,14 @@ class ExpressionTest extends munit.FunSuite:
     eval("foo(foo(1, 2), foo(3, 4))", 10.0)
     parse("bar(x, y, z) = x + y + z")
     eval("1 + bar(foo(2, 1), 3, 4 + foo(5, 1))", 17.0)
+    shouldReturnParsingError("foo(1,,2)")
+  }
+
+  test("Functions with zero arguments") {
+    implicit val parser: Parser = Parser() // the same parser will be used in all evaluations
+    parse("foo() = 1")
+    eval("foo", 1.0)
+    eval("foo()", 1.0)
   }
 
   test("Function using previously defined values") {


### PR DESCRIPTION
The empty arguments list is allowed, but an empty argument on a non-empty list is an error.