### PR TITLE
fix: Clean special assignments

### DIFF
--- a/src/main/scala/replcalc/Dictionary.scala
+++ b/src/main/scala/replcalc/Dictionary.scala
@@ -3,21 +3,21 @@ package replcalc
 import replcalc.Dictionary.isValidName
 import replcalc.expressions.{Expression, Assignment}
 
-final class Dictionary(private var expressions: Map[String, Expression] = Map.empty,
+final class Dictionary(private var map: Map[String, Expression] = Map.empty,
                        private var specialValuesCounter: Long = 0L):
   def canAssign(name: String): Boolean =
-    expressions.get(name) match
+    map.get(name) match
       case Some(_ : Assignment)      => true
       case None if isValidName(name) => true
       case _                         => false
   
   def add(name: String, expr: Expression): Boolean =
-    expressions.get(name) match
+    map.get(name) match
       case Some(_ : Assignment) =>
-        expressions += name -> expr
+        map += name -> expr
         true
       case None if isValidName(name) =>
-        expressions += name -> expr
+        map += name -> expr
         true
       case _ =>
         false
@@ -25,19 +25,20 @@ final class Dictionary(private var expressions: Map[String, Expression] = Map.em
   def addSpecial(expr: Expression): String =
     specialValuesCounter += 1
     val name = s"$$$specialValuesCounter"
-    expressions += name -> expr
+    map += name -> expr
     name
   
-  inline def get(name: String): Option[Expression] = expressions.get(name)
+  inline def get(name: String): Option[Expression] = map.get(name)
 
-  inline def contains(name: String): Boolean = expressions.contains(name)
+  inline def contains(name: String): Boolean = map.contains(name)
 
-  inline def names: Set[String] = expressions.keySet.filter(_.head != '$')
+  inline def expressions: Map[String, Expression] = map.filter(_._1.head != '$')
 
-  inline def allExpressions: Seq[Expression] = expressions.filter(_._1.head != '$').toSeq.sortBy(_._1).map(_._2)
-
-  def copy(updates: Map[String, Expression]): Dictionary = 
-    Dictionary(expressions ++ updates, specialValuesCounter)
+  inline def specials: Map[String, Expression] = map.filter(_._1.head == '$')
+  
+  def cleanSpecials(): Unit = map = map.view.filterKeys(_.head != '$').toMap
+  
+  def copy(updates: Map[String, Expression]): Dictionary = Dictionary(map ++ updates, specialValuesCounter)
   
 object Dictionary:
   def isValidName(name: String, canBeSpecial: Boolean = false): Boolean =

--- a/src/main/scala/replcalc/Main.scala
+++ b/src/main/scala/replcalc/Main.scala
@@ -18,14 +18,17 @@ def main(args: String*): Unit =
 
 private def list(dictionary: Dictionary): Unit =
   dictionary
-    .allExpressions
+    .expressions
+    .toSeq.sortBy(_._1).map(_._2)
     .map(replForm(dictionary, _))
     .foreach(println)
   
 private def evaluate(parser: Parser, line: String): Option[String] =
   parser.parse(line).map {
-    case Right(expr) => replForm(parser.dictionary, expr)
-    case Left(error) => s"Parsing error: ${error.msg}"
+    case Right(expr) =>
+      replForm(parser.dictionary, expr).tap { _ => parser.dictionary.cleanSpecials() }
+    case Left(error) =>
+      s"Parsing error: ${error.msg}"
   }
 
 private def replForm(dictionary: Dictionary, expression: Expression): String =

--- a/src/test/scala/replcalc/DictionaryTest.scala
+++ b/src/test/scala/replcalc/DictionaryTest.scala
@@ -23,7 +23,7 @@ class DictionaryTest extends munit.FunSuite:
     val dict = Dictionary()
     dict.add("a", Constant(1.0))
     dict.add("b", Constant(2.0))
-    assertEquals(dict.names, Set("a", "b"))
+    assertEquals(dict.expressions.keySet, Set("a", "b"))
   }
 
   test("Handle an attempt to get an unassigned expression") {
@@ -51,4 +51,14 @@ class DictionaryTest extends munit.FunSuite:
     assert(!Dictionary.isValidName("()"))
     assert(!Dictionary.isValidName(""))
     assert(!Dictionary.isValidName("1a"))
+  }
+
+  test("Create and remove special assignments") {
+    val dict = Dictionary()
+    dict.addSpecial(Constant(1.0))
+    dict.addSpecial(Constant(2.0))
+    dict.addSpecial(Constant(3.0))
+    assertEquals(dict.specials.size, 3)
+    dict.cleanSpecials()
+    assert(dict.specials.isEmpty)
   }

--- a/src/test/scala/replcalc/PreprocessorTest.scala
+++ b/src/test/scala/replcalc/PreprocessorTest.scala
@@ -87,6 +87,7 @@ class PreprocessorTest extends munit.FunSuite:
     shouldFailParens("(1+2)+(")
     shouldFailParens("(1+(2+(3+4)+5)+6")
     shouldFailParens("1+((2+(3+4)+5)+6")
+    shouldFailParens("(1+2)3")
   }
 
   test("Ignore function parentheses") {


### PR DESCRIPTION
Every time the user types in an expression with parentheses, special assignments are put in the dictionary. They are used to process the expression but they are not used later. In practice they could just stay in the dictionary forever - the user would never manage to use up all the memory - but it also doesn't hurt to clean them after the expression is processed.

I also used this opportunity to fix a bug where numbers put directly after the closing parenthesis could be interpreted as a part of the special assignment's name (e.g. "(1+2)3" would turn into "$13" where it should be "$1" and "3" should be recognized as an error).