### PR TITLE
refactor: Extract traits for Parser and Preprocessor

### DIFF
--- a/src/test/scala/replcalc/PreprocessorTest.scala
+++ b/src/test/scala/replcalc/PreprocessorTest.scala
@@ -8,7 +8,7 @@ class PreprocessorTest extends munit.FunSuite:
   implicit val location: Location = Location.empty
 
   private def setup(flags: Flags = Flags.AllFlagsOn): Preprocessor =
-    val parser = new Parser(Dictionary(), None)
+    val parser: Parser = new ParserImpl(Dictionary(), None)
     Preprocessor(parser, flags).tap { parser.setup }
 
   private def evalParens(line: String, prefix: String = "", suffix: String = "")(implicit pre: Preprocessor = setup()): Unit =


### PR DESCRIPTION
It hardly matters for such a small project but I use this pattern a lot in my work so I thought I would do it here
as well just to show how I like to organize the code.

For entities wrapping logic, such as `Parser` and `Preprocessor` here, I like to have a trait and an implementation class, and then an `apply` method which makes it pretty invisible from the outside that it is not just one regular class. The separation of the trait and the implementation lets me better see what parts of the functionality should be hidden, it lets me write mocks easier in unit tests, and from time to time it actually makes sense to have, e.g., two different implementations of one trait.

Note that I didn't do it for `Dictionary`. I still consider `Dictionary` to be just a thin wrapper around `Map[String, Expression]`.