### PR TITLE
feat: Handle floating point imprecision

### DIFF
--- a/src/main/scala/replcalc/Main.scala
+++ b/src/main/scala/replcalc/Main.scala
@@ -14,7 +14,7 @@ def main(args: String*): Unit =
       case ":exit"              => exit = true
       case ":list"              => list(parser.dictionary)
       case line if line.isEmpty =>
-      case line                 => evaluate(parser, line).foreach(println)
+      case line                 => run(parser, line).foreach(println)
 
 private def list(dictionary: Dictionary): Unit =
   dictionary
@@ -23,7 +23,7 @@ private def list(dictionary: Dictionary): Unit =
     .map(replForm(dictionary, _))
     .foreach(println)
   
-private def evaluate(parser: Parser, line: String): Option[String] =
+private def run(parser: Parser, line: String): Option[String] =
   parser.parse(line).map {
     case Right(expr) =>
       replForm(parser.dictionary, expr).tap { _ => parser.dictionary.cleanSpecials() }
@@ -38,6 +38,6 @@ private def replForm(dictionary: Dictionary, expression: Expression): String =
     case Assignment(name, Constant(number)) =>
       s"$name -> $number"
     case expr =>
-      expr.evaluate(dictionary) match
+      expr.run(dictionary) match
         case Right(result) => result.toString
         case Left(error)   => s"Evaluation error: ${error.msg}"

--- a/src/main/scala/replcalc/expressions/AddSubstract.scala
+++ b/src/main/scala/replcalc/expressions/AddSubstract.scala
@@ -6,10 +6,10 @@ import replcalc.{Dictionary, Parser}
 import replcalc.Parser.isOperator
 
 final case class AddSubstract(left: Expression, right: Expression, isSubstraction: Boolean = false) extends Expression:
-  override def evaluate(dict: Dictionary): Either[Error, Double] =
+  override protected def evaluate(dict: Dictionary): Either[Error, Double] =
     for
-      lResult <- left.evaluate(dict)
-      rResult <- right.evaluate(dict)
+      lResult <- left.run(dict)
+      rResult <- right.run(dict)
     yield
       if isSubstraction then 
         lResult - rResult 

--- a/src/main/scala/replcalc/expressions/Assignment.scala
+++ b/src/main/scala/replcalc/expressions/Assignment.scala
@@ -5,7 +5,7 @@ import replcalc.{Dictionary, Parser}
 import scala.util.chaining.*
 
 final case class Assignment(name: String, constant: Constant) extends Expression:
-  override def evaluate(dict: Dictionary): Either[Error, Double] = constant.evaluate(dict)
+  override protected def evaluate(dict: Dictionary): Either[Error, Double] = constant.run(dict)
 
 object Assignment extends Parseable[Assignment]:
   override def parse(parser: Parser, line: String): ParsedExpr[Assignment] =
@@ -24,7 +24,7 @@ object Assignment extends Parseable[Assignment]:
       parser
         .parse(expressionStr)
         .happyPath {
-          _.evaluate(parser.dictionary).map { number =>
+          _.run(parser.dictionary).map { number =>
             Assignment(name, Constant(number)).tap(parser.dictionary.add(name, _))
           }.pipe(Some(_))
         }

--- a/src/main/scala/replcalc/expressions/Constant.scala
+++ b/src/main/scala/replcalc/expressions/Constant.scala
@@ -4,7 +4,7 @@ import Error.ParsingError
 import replcalc.{Dictionary, Parser}
 
 final case class Constant(number: Double) extends Expression:
-  override def evaluate(dict: Dictionary): Either[Error, Double] = Right(number)
+  override protected def evaluate(dict: Dictionary): Either[Error, Double] = Right(number)
 
 object Constant extends Parseable[Constant]:
   override def parse(parser: Parser, line: String): ParsedExpr[Constant] =

--- a/src/main/scala/replcalc/expressions/Expression.scala
+++ b/src/main/scala/replcalc/expressions/Expression.scala
@@ -7,5 +7,14 @@ trait Parseable[T <: Expression]:
   def parse(parser: Parser, line: String): ParsedExpr[T]
 
 trait Expression:
-  def evaluate(dict: Dictionary): Either[Error, Double]
+  protected def evaluate(dict: Dictionary): Either[Error, Double]
+  final def run(dict: Dictionary): Either[Error, Double] = evaluate(dict).map(Expression.round(_))
 
+object Expression:
+  // A magic number. This should be equal to 0.0 but isn't - it's around 1.1E-16 - because of floating point imprecision.
+  // To "fix" it, we treat every evaluation result less or equal to this as if it was 0.0.
+  private val DIVISION_PRECISION: Double =
+   ((1.0/3.0)*3.0)-(1.0/3.0)-(1.0/3.0)-(1.0/3.0)
+
+  inline def isZero(number: Double): Boolean = scala.math.abs(number) <= DIVISION_PRECISION
+  inline def round(number: Double): Double = if isZero(number) then 0.0 else number

--- a/src/main/scala/replcalc/expressions/Function.scala
+++ b/src/main/scala/replcalc/expressions/Function.scala
@@ -4,11 +4,11 @@ import replcalc.{Dictionary, Parser, Preprocessor}
 import replcalc.expressions.Error.{EvaluationError, ParsingError}
 
 final case class Function(name: String, args: Seq[Expression]) extends Expression:
-  override def evaluate(dict: Dictionary): Either[Error, Double] =
+  override protected def evaluate(dict: Dictionary): Either[Error, Double] =
     dict.get(name) match
       case Some(f: FunctionAssignment) if f.argNames.length == args.length =>
         val argMap = f.argNames.zip(args).toMap
-        f.evaluate(dict.copy(argMap))
+        f.run(dict.copy(argMap))
       case _ =>
         Left(EvaluationError(s"Function not found: $name"))
 

--- a/src/main/scala/replcalc/expressions/FunctionAssignment.scala
+++ b/src/main/scala/replcalc/expressions/FunctionAssignment.scala
@@ -5,7 +5,7 @@ import replcalc.{Dictionary, Parser, Preprocessor}
 import scala.util.chaining.*
 
 final case class FunctionAssignment(name: String, argNames: Seq[String], expr: Expression) extends Expression:
-  override def evaluate(dict: Dictionary): Either[Error, Double] = expr.evaluate(dict)
+  override protected def evaluate(dict: Dictionary): Either[Error, Double] = expr.run(dict)
 
 object FunctionAssignment extends Parseable[FunctionAssignment]:
   override def parse(parser: Parser, line: String): ParsedExpr[FunctionAssignment] =

--- a/src/main/scala/replcalc/expressions/MultiplyDivide.scala
+++ b/src/main/scala/replcalc/expressions/MultiplyDivide.scala
@@ -2,18 +2,19 @@ package replcalc.expressions
 
 import Error.*
 import replcalc.{Dictionary, Parser}
+import Expression.isZero
 
 final case class MultiplyDivide(left: Expression, right: Expression, isDivision: Boolean = false) extends Expression:
-  override def evaluate(dict: Dictionary): Either[Error, Double] =
+  override protected def evaluate(dict: Dictionary): Either[Error, Double] =
     val innerResults =
       for
-        lResult <- left.evaluate(dict)
-        rResult <- right.evaluate(dict)
+        lResult <- left.run(dict)
+        rResult <- right.run(dict)
       yield (lResult, rResult)
     innerResults.flatMap {
-      case (l, r) if isDivision && r == 0.0 => Left(EvaluationError(s"Division by zero: $l / $r"))
-      case (l, r) if isDivision             => Right(l / r)
-      case (l, r)                           => Right(l * r)
+      case (l, r) if isDivision && isZero(r) => Left(EvaluationError(s"Division by zero: $l / $r"))
+      case (l, r) if isDivision              => Right(l / r)
+      case (l, r)                            => Right(l * r)
     }
 
 object MultiplyDivide extends Parseable[MultiplyDivide]:
@@ -34,3 +35,4 @@ object MultiplyDivide extends Parseable[MultiplyDivide]:
         case (_, Left(error))     => Left(error)
         case (Right(l), Right(r)) => Right(MultiplyDivide(l, r, isDivision))
       }
+

--- a/src/main/scala/replcalc/expressions/UnaryMinus.scala
+++ b/src/main/scala/replcalc/expressions/UnaryMinus.scala
@@ -4,7 +4,7 @@ import Error.ParsingError
 import replcalc.{Dictionary, Parser, expressions}
 
 final case class UnaryMinus(innerExpr: Expression) extends Expression:
-  override def evaluate(dict: Dictionary): Either[Error, Double] = innerExpr.evaluate(dict).map(-_)
+  override protected def evaluate(dict: Dictionary): Either[Error, Double] = innerExpr.run(dict).map(-_)
   
 object UnaryMinus extends Parseable[UnaryMinus]:
   override def parse(parser: Parser, line: String): ParsedExpr[UnaryMinus] =

--- a/src/main/scala/replcalc/expressions/Variable.scala
+++ b/src/main/scala/replcalc/expressions/Variable.scala
@@ -4,10 +4,10 @@ import Error.{ParsingError, EvaluationError}
 import replcalc.{Dictionary, Parser}
 
 final case class Variable(name: String) extends Expression:
-  override def evaluate(dict: Dictionary): Either[Error, Double] =
+  override protected def evaluate(dict: Dictionary): Either[Error, Double] =
     dict
       .get(name)
-      .map(_.evaluate(dict))
+      .map(_.run(dict))
       .getOrElse(Left(EvaluationError(s"Variable not found: $name")))
   
 object Variable extends Parseable[Variable]:

--- a/src/test/scala/replcalc/ExpressionTest.scala
+++ b/src/test/scala/replcalc/ExpressionTest.scala
@@ -13,7 +13,7 @@ class ExpressionTest extends munit.FunSuite:
       case Some(Left(error)) => 
         failComparison(s"Error: ${error.msg}", str, expected)
       case Some(Right(expr)) =>
-        expr.evaluate(parser.dictionary) match
+        expr.run(parser.dictionary) match
           case Right(result) => assertEqualsDouble(result, expected, delta)
           case Left(error)   => failComparison(s"Error: ${error.msg}", str, expected)
 
@@ -66,6 +66,10 @@ class ExpressionTest extends munit.FunSuite:
     eval("3/2/2", 0.75)
     eval("1.0/2.0", 0.5)
     intercept[ComparisonFailException](eval("1/0", Double.NaN))
+  }
+
+  test("Round to zero") {
+    eval("(1/3)*3-1/3-1/3-1/3", 0.0)
   }
 
   test("Multiply and Divide") {


### PR DESCRIPTION
A final touch. Sometimes, with more complex equations, you may find out that zero is not always zero, due to floating point issues on JVM (and basically everywhere else). I tried to remedy it with calculation a magic number that will be used as a precision point for expressions: any result closer to zero than this will be considered to be zero.

Therese is a bit of boilerplate code but it allows for adding more checks like this in the future.