### PR TITLE
refactor: Additional preprocessor decoupling

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
+
 name := "replcalc"
 
-version := "0.1"
+version := "1.0"
 scalaVersion := "3.1.0"
 
 scalacOptions ++= Seq(

--- a/src/main/scala/replcalc/Dictionary.scala
+++ b/src/main/scala/replcalc/Dictionary.scala
@@ -3,21 +3,21 @@ package replcalc
 import replcalc.Dictionary.isValidName
 import replcalc.expressions.{Expression, Assignment}
 
-final class Dictionary(private var map: Map[String, Expression] = Map.empty,
+final class Dictionary(private var dict: Map[String, Expression] = Map.empty,
                        private var specialValuesCounter: Long = 0L):
   def canAssign(name: String): Boolean =
-    map.get(name) match
+    dict.get(name) match
       case Some(_ : Assignment)      => true
       case None if isValidName(name) => true
       case _                         => false
   
   def add(name: String, expr: Expression): Boolean =
-    map.get(name) match
+    dict.get(name) match
       case Some(_ : Assignment) =>
-        map += name -> expr
+        dict += name -> expr
         true
       case None if isValidName(name) =>
-        map += name -> expr
+        dict += name -> expr
         true
       case _ =>
         false
@@ -25,23 +25,26 @@ final class Dictionary(private var map: Map[String, Expression] = Map.empty,
   def addSpecial(expr: Expression): String =
     specialValuesCounter += 1
     val name = s"$$$specialValuesCounter"
-    map += name -> expr
+    dict += name -> expr
     name
   
-  inline def get(name: String): Option[Expression] = map.get(name)
+  inline def get(name: String): Option[Expression] = dict.get(name)
 
-  inline def contains(name: String): Boolean = map.contains(name)
+  inline def contains(name: String): Boolean = dict.contains(name)
 
-  inline def expressions: Map[String, Expression] = map.filter(_._1.head != '$')
+  inline def expressions: Map[String, Expression] = dict.filter(_._1.head != '$')
 
-  inline def specials: Map[String, Expression] = map.filter(_._1.head == '$')
+  inline def specials: Map[String, Expression] = dict.filter(_._1.head == '$')
   
-  def cleanSpecials(): Unit = map = map.view.filterKeys(_.head != '$').toMap
+  def clean(): Unit =
+    dict = dict.view.filterKeys(_.head != '$').toMap
   
-  def copy(updates: Map[String, Expression]): Dictionary = Dictionary(map ++ updates, specialValuesCounter)
+  def copy(updates: Map[String, Expression]): Dictionary =
+    Dictionary(dict ++ updates, specialValuesCounter)
   
 object Dictionary:
   def isValidName(name: String, canBeSpecial: Boolean = false): Boolean =
     name.nonEmpty &&
+      name.exists(_ != '_') &&
       (name.head.isLetter || name.head == '_' || (canBeSpecial && name.head == '$')) &&
       name.substring(1).forall(ch => ch.isLetterOrDigit || ch == '_')

--- a/src/main/scala/replcalc/Main.scala
+++ b/src/main/scala/replcalc/Main.scala
@@ -26,7 +26,7 @@ private def list(dictionary: Dictionary): Unit =
 private def run(parser: Parser, line: String): Option[String] =
   parser.parse(line).map {
     case Right(expr) =>
-      replForm(parser.dictionary, expr).tap { _ => parser.dictionary.cleanSpecials() }
+      replForm(parser.dictionary, expr).tap { _ => parser.dictionary.clean() }
     case Left(error) =>
       s"Parsing error: ${error.msg}"
   }

--- a/src/main/scala/replcalc/Parser.scala
+++ b/src/main/scala/replcalc/Parser.scala
@@ -38,9 +38,11 @@ final class ParserImpl(override val dictionary: Dictionary,
       case None      => Left(Error.PreprocessorError("The preprocessor is not set up"))
 
 object Parser:
-  def apply(dictionary: Dictionary = Dictionary()): Parser =
+  def apply(dictionary: Dictionary = Dictionary(), flags: Flags = Flags.AllFlagsOn): Parser =
     new ParserImpl(dictionary, None).tap { parser =>
-      parser.setup(Preprocessor(parser))
+      val preprocessor = Preprocessor(flags = flags)
+      parser.setup(preprocessor)
+      preprocessor.setup(parser)
     }
 
   def isOperator(char: Char, additionalAllowed: Char*): Boolean = 

--- a/src/test/scala/replcalc/DictionaryTest.scala
+++ b/src/test/scala/replcalc/DictionaryTest.scala
@@ -51,6 +51,8 @@ class DictionaryTest extends munit.FunSuite:
     assert(!Dictionary.isValidName("()"))
     assert(!Dictionary.isValidName(""))
     assert(!Dictionary.isValidName("1a"))
+    assert(!Dictionary.isValidName("_"))
+    assert(!Dictionary.isValidName("__"))
   }
 
   test("Create and remove special assignments") {
@@ -59,6 +61,6 @@ class DictionaryTest extends munit.FunSuite:
     dict.addSpecial(Constant(2.0))
     dict.addSpecial(Constant(3.0))
     assertEquals(dict.specials.size, 3)
-    dict.cleanSpecials()
+    dict.clean()
     assert(dict.specials.isEmpty)
   }

--- a/src/test/scala/replcalc/PreprocessorTest.scala
+++ b/src/test/scala/replcalc/PreprocessorTest.scala
@@ -9,7 +9,7 @@ class PreprocessorTest extends munit.FunSuite:
 
   private def setup(flags: Flags = Flags.AllFlagsOn): Preprocessor =
     val parser: Parser = new ParserImpl(Dictionary(), None)
-    Preprocessor(parser, flags).tap { parser.setup }
+    new PreprocessorImpl(Some(parser), flags).tap { parser.setup }
 
   private def evalParens(line: String, prefix: String = "", suffix: String = "")(implicit pre: Preprocessor = setup()): Unit =
     pre.process(line) match


### PR DESCRIPTION
After giving it some thought I decided to treat `Preprocessor` the same as `Parser`. Now it can also be created without the other one, and then the new `setup` method can be used to connect them. There is an utility `apply` method in `Parser` to do it, so `Parser` can be still seen as a bit more important of the two.

Plus a few minor changes to `Dictionary`. From now on a valid variable name can't consist of only "_".