### PR TITLE
refactor: Parse function line

### DIFF
--- a/src/main/scala/replcalc/expressions/Function.scala
+++ b/src/main/scala/replcalc/expressions/Function.scala
@@ -1,6 +1,8 @@
 package replcalc.expressions
 
+import replcalc.Preprocessor.ParsedFunction
 import replcalc.{Dictionary, Parser, Preprocessor}
+import replcalc.Preprocessor.LineSide
 import replcalc.expressions.Error.{EvaluationError, ParsingError}
 
 final case class Function(name: String, args: Seq[Expression]) extends Expression:
@@ -10,39 +12,27 @@ final case class Function(name: String, args: Seq[Expression]) extends Expressio
         val argMap = f.argNames.zip(args).toMap
         f.run(dict.copy(argMap))
       case _ =>
-        Left(EvaluationError(s"Function not found: $name"))
+        Left(EvaluationError(s"Function not found: $name with ${args.length} arguments"))
 
 object Function extends Parseable[Function]:
   override def parse(parser: Parser, line: String): ParsedExpr[Function] =
-    Preprocessor.findParens(line, functionParens = true).flatMap {
+    Preprocessor.parseFunction(line, LineSide.Right).flatMap {
       case Left(error) =>
         ParsedExpr.error(error)
-      case Right((_, closing)) if closing + 1 < line.length =>
-        ParsedExpr.error(s"Unrecognized chunk of a function expression: ${line.substring(closing + 1)}")
-      case Right((opening, closing)) =>
-        val name      = line.substring(0, opening)
-        val arguments = line.substring(opening + 1, closing)
+      case Right(ParsedFunction(name, _)) if !parser.dictionary.contains(name) =>
+        ParsedExpr.error(s"Function not found: $name")
+      case Right(ParsedFunction(name, arguments)) =>
         parseFunction(parser, name, arguments)
     }
 
-  private def parseFunction(parser: Parser, name: String, arguments: String): ParsedExpr[Function] =
-    if !Dictionary.isValidName(name) then
-      ParsedExpr.empty
-    else if !parser.dictionary.contains(name) then
-      ParsedExpr.error(s"Function not found: $name")
+  private def parseFunction(parser: Parser, name: String, args: Seq[String]): ParsedExpr[Function] =
+    val parsedArgs = args.map { arg => arg -> parser.parse(arg) }
+    val errors = parsedArgs.collect {
+      case (argName, None)              => s"Unable to parse argument $argName"
+      case (argName, Some(Left(error))) => s"Unable to parse argument $argName: ${error.msg}"
+    }
+    if errors.nonEmpty then
+      ParsedExpr.error(errors.mkString("; "))
     else
-      val args =
-        if arguments.nonEmpty then
-          arguments.split(",").map { arg => arg -> parser.parse(arg) }.toSeq
-        else
-          Seq.empty
-      val errors = args.collect {
-        case (argName, _) if argName.isEmpty => "Empty argument"
-        case (argName, None)                 => s"Unable to parse argument: $argName"
-        case (argName, Some(Left(error)))    => s"Error while parsing argument $argName: ${error.msg}"
-      }
-      if errors.nonEmpty then
-        ParsedExpr.error(errors.mkString("; "))
-      else
-        val validArgs = args.collect { case (_, Some(Right(expr))) => expr }
-        ParsedExpr(Function(name, validArgs))
+      val validArgs = parsedArgs.collect { case (_, Some(Right(expr))) => expr }
+      ParsedExpr(Function(name, validArgs))


### PR DESCRIPTION
A part of line of the form `functionName(arg1,arg2,...)` is now handled in two places - it can be a function assignment, or a function evaluated in an expression. On top of that, I'm working on a fix to a bug that will require to handle it once more, in the preprocessor. To make it easier, I decided to extract the logic that turns such a piece of text into a small case class to a separate function.