### PR TITLE
fix: Function arguments used inside parentheses

### DIFF
--- a/src/main/scala/replcalc/Dictionary.scala
+++ b/src/main/scala/replcalc/Dictionary.scala
@@ -3,20 +3,21 @@ package replcalc
 import replcalc.Dictionary.isValidName
 import replcalc.expressions.{Expression, Assignment}
 
-final class Dictionary(private var dict: Map[String, Expression] = Map.empty,
-                       private var specialValuesCounter: Long = 0L):
+final class Dictionary(private var dict: Map[String, Expression] = Map.empty):
+  import Dictionary.specialValuesCounter
+
   def canAssign(name: String): Boolean =
     dict.get(name) match
       case Some(_ : Assignment)      => true
       case None if isValidName(name) => true
       case _                         => false
-  
-  def add(name: String, expr: Expression): Boolean =
+
+  def add(name: String, expr: Expression, canBeSpecial: Boolean = false): Boolean =
     dict.get(name) match
       case Some(_ : Assignment) =>
         dict += name -> expr
         true
-      case None if isValidName(name) =>
+      case None if isValidName(name, canBeSpecial) =>
         dict += name -> expr
         true
       case _ =>
@@ -27,7 +28,7 @@ final class Dictionary(private var dict: Map[String, Expression] = Map.empty,
     val name = s"$$$specialValuesCounter"
     dict += name -> expr
     name
-  
+
   inline def get(name: String): Option[Expression] = dict.get(name)
 
   inline def contains(name: String): Boolean = dict.contains(name)
@@ -35,14 +36,12 @@ final class Dictionary(private var dict: Map[String, Expression] = Map.empty,
   inline def expressions: Map[String, Expression] = dict.filter(_._1.head != '$')
 
   inline def specials: Map[String, Expression] = dict.filter(_._1.head == '$')
-  
-  def clean(): Unit =
-    dict = dict.view.filterKeys(_.head != '$').toMap
-  
-  def copy(updates: Map[String, Expression]): Dictionary =
-    Dictionary(dict ++ updates, specialValuesCounter)
-  
+
+  def copy(updates: Map[String, Expression]): Dictionary = Dictionary(dict ++ updates)
+
 object Dictionary:
+  private var specialValuesCounter: Long = 0L
+
   def isValidName(name: String, canBeSpecial: Boolean = false): Boolean =
     name.nonEmpty &&
       name.exists(_ != '_') &&

--- a/src/main/scala/replcalc/Main.scala
+++ b/src/main/scala/replcalc/Main.scala
@@ -25,10 +25,8 @@ private def list(dictionary: Dictionary): Unit =
   
 private def run(parser: Parser, line: String): Option[String] =
   parser.parse(line).map {
-    case Right(expr) =>
-      replForm(parser.dictionary, expr).tap { _ => parser.dictionary.clean() }
-    case Left(error) =>
-      s"Parsing error: ${error.msg}"
+    case Right(expr) => replForm(parser.dictionary, expr)
+    case Left(error) => s"Parsing error: ${error.msg}"
   }
 
 private def replForm(dictionary: Dictionary, expression: Expression): String =

--- a/src/test/scala/replcalc/DictionaryTest.scala
+++ b/src/test/scala/replcalc/DictionaryTest.scala
@@ -61,6 +61,5 @@ class DictionaryTest extends munit.FunSuite:
     dict.addSpecial(Constant(2.0))
     dict.addSpecial(Constant(3.0))
     assertEquals(dict.specials.size, 3)
-    dict.clean()
-    assert(dict.specials.isEmpty)
+    assertEquals(dict.specials.values.toSet, Set(Constant(1.0), Constant(2.0), Constant(3.0)))
   }

--- a/src/test/scala/replcalc/ExpressionTest.scala
+++ b/src/test/scala/replcalc/ExpressionTest.scala
@@ -8,9 +8,9 @@ class ExpressionTest extends munit.FunSuite:
 
   private def eval(str: String, expected: Double, delta: Double = 0.001)(implicit parser: Parser = Parser()): Unit =
     parser.parse(str) match
-      case None => 
+      case None =>
         failComparison("Parsed as 'none'", str, expected)
-      case Some(Left(error)) => 
+      case Some(Left(error)) =>
         failComparison(s"Error: ${error.msg}", str, expected)
       case Some(Right(expr)) =>
         expr.run(parser.dictionary) match
@@ -141,6 +141,7 @@ class ExpressionTest extends munit.FunSuite:
   }
 
   test("Expressions with parentheses") {
+    eval("((1))", 1.0)
     eval("1 + (2 + 3) + 4", 10.0)
     eval("1 - (2 + 3) - 4", -8.0)
     eval("-(3*-2)", 6.0)
@@ -157,6 +158,8 @@ class ExpressionTest extends munit.FunSuite:
     shouldReturnParsingError("myFunc(x) = y")
     shouldReturnParsingError("baz(x)blabla = x")
     shouldReturnParsingError("boo(x,,y) = x + y")
+    parse("cat(x)=(1+x)")
+    eval("cat(0)", 1.0)
   }
 
   test("Functions with one argument") {


### PR DESCRIPTION
A very nasty bug. Two in fact, but connected. It involves function arguments and parentheses replaced by special variables.

Let's consider a function assignment which looks like this: `f(x) = (1 + x)`. There would be no problem if no parentheses were used. But the way it is now, the preprocessor tries to put the nested expression `1+x` in the dictionary under a special name and then replace the parentheses with it. The problem is, to do it, `1+x` must be parsed, and the parser doesn't know that `x` is a function argument. It would know if there were no parentheses because then the whole line would be parsed as a function assignment, but here the parser has only the chunk `1+x` and no information that this is a function assignment.

To fix it, I make a copy of the original parser, updated with the function arguments. This way parsing works now, but it creates additional complexity: all special variables made when removing parentheses are now put into the new parser, not the original one. So after it's done, I need to update the original one with new special variables from the new one.

And that led me to the second bug: Some time ago I introduced cleaning the dictionary from special variables, thinking that after an expression is evaluated, the special variables used in evaluation are no longer needed. But that's not true for function assignments. They are evaluated on demand, possibly many times, and they require the special variables to still be in the dictionary. So cleaning would have to be much smarter than just removing special variables - it would have to look through function assignments and figure out which special variables are in use.
Instead, I removed cleaning for now. I assume that since this is a simple REPL calculator, then there is no risk in keeping the special variables in the memory. There will never be too many of them.

There is a way to fix both these bugs in a more scalable way: A function should carry its own dictionary with arguments, special variables, and everything else needed to evaluate it. It's called "a stack frame" and it's how compilers deal with functions (as far as I remember from my studies). But since this is just a calculator, I decided to stop at this point. But if I was to develop this project further, I would certainly consider to rewrite this functionality like that.