### PR TITLE
feat: More info about the error type

### DIFF
--- a/src/main/scala/replcalc/Main.scala
+++ b/src/main/scala/replcalc/Main.scala
@@ -1,6 +1,7 @@
 package replcalc
 
 import replcalc.expressions.{Constant, Expression, FunctionAssignment, Assignment}
+import replcalc.expressions.Error.{ParsingError, PreprocessorError, EvaluationError}
 import scala.util.chaining.*
 import scala.io.StdIn.readLine
 
@@ -22,12 +23,14 @@ private def list(dictionary: Dictionary): Unit =
     .toSeq.sortBy(_._1).map(_._2)
     .map(replForm(dictionary, _))
     .foreach(println)
-  
+
 private def run(parser: Parser, line: String): Option[String] =
-  parser.parse(line).map {
-    case Right(expr) => replForm(parser.dictionary, expr)
-    case Left(error) => s"Parsing error: ${error.msg}"
-  }
+  parser
+    .parse(line)
+    .map {
+      case Right(expr) => replForm(parser.dictionary, expr)
+      case Left(error) => error.toString
+    }
 
 private def replForm(dictionary: Dictionary, expression: Expression): String =
   expression match
@@ -38,4 +41,4 @@ private def replForm(dictionary: Dictionary, expression: Expression): String =
     case expr =>
       expr.run(dictionary) match
         case Right(result) => result.toString
-        case Left(error)   => s"Evaluation error: ${error.msg}"
+        case Left(error)   => error.toString

--- a/src/main/scala/replcalc/expressions/Error.scala
+++ b/src/main/scala/replcalc/expressions/Error.scala
@@ -1,6 +1,9 @@
 package replcalc.expressions
 
-enum Error(val msg: String):
-  case ParsingError(override val msg: String) extends Error(msg)
-  case EvaluationError(override val msg: String) extends Error(msg)
-  case PreprocessorError(override val msg: String) extends Error(msg)
+enum Error(val msg: String, private val title: String):
+  case ParsingError(override val msg: String) extends Error(msg, "Parsing error")
+  case EvaluationError(override val msg: String) extends Error(msg, "Evaluation error")
+  case PreprocessorError(override val msg: String) extends Error(msg, "Preprocessor error")
+
+  override def toString: String = s"$title: $msg"
+end Error


### PR DESCRIPTION
When the REPL informs the user about an error, the message now will be more consistent - the error type is added at the front of the message automatically, so there's no need to write it in the message.