### PR TITLE
refactor: Optimize whitespaces removal

### DIFF
--- a/src/main/scala/replcalc/Preprocessor.scala
+++ b/src/main/scala/replcalc/Preprocessor.scala
@@ -71,7 +71,11 @@ object Preprocessor:
             Right(ParsedFunction(functionName, arguments))
     }
 
-  def removeWhitespaces(line: String): Either[Error, String] = Right(line.filterNot(_.isWhitespace))
+    def removeWhitespaces(line: String): Either[Error, String] =
+      if line.exists(_.isWhitespace) then
+        Right(line.filterNot(_.isWhitespace))
+      else
+        Right(line)
 
   def wrapFunctionArguments(line: String): Either[Error, String] =
     withParens(line, functionParens = true) { (opening, closing) =>


### PR DESCRIPTION
It turns out the method removing whitespaces allocates a new String even if there are no whitespaces to remove and the whole original line is just copied. I missed that. This optimization checks if the allocation is necessary or if it's enough to return the original line.