### PR TITLE
refactor: Move ParsedFunction to a separate file

### DIFF
--- a/src/main/scala/replcalc/ParsedFunction.scala
+++ b/src/main/scala/replcalc/ParsedFunction.scala
@@ -1,0 +1,37 @@
+package replcalc
+
+import replcalc.Dictionary.isValidName
+import replcalc.expressions.Error
+import replcalc.expressions.Error.ParsingError
+import replcalc.Preprocessor.{findParens, splitByCommas}
+
+final case class ParsedFunction(name: String, arguments: Seq[String])
+
+object ParsedFunction:
+  enum LineSide:
+    case Left
+    case Right
+
+  def parse(line: String, lineSide: LineSide): Option[Either[Error, ParsedFunction]] =
+    findParens(line, functionParens = true).map {
+      case Left(error) =>
+        Left(error)
+      case Right((_, closing)) if closing + 1 < line.length =>
+        Left(ParsingError(s"Unrecognized chunk of a function expression: ${line.substring(closing + 1)}"))
+      case Right((opening, closing)) =>
+        val name = line.substring(0, opening)
+        if !isValidName(name) then
+          Left(ParsingError(s"Invalid function name: $name"))
+        else
+          val argStr    = line.substring(opening + 1, closing)
+          val arguments = splitByCommas(argStr)
+          val errors    = arguments.collect {
+            case argName if argName.isEmpty                                    => "Empty argument name"
+            case argName if lineSide == LineSide.Left && !isValidName(argName) => argName
+          }
+          if errors.nonEmpty then
+            Left(ParsingError(s"Invalid argument(s): ${errors.mkString(", ")}"))
+          else
+            Right(ParsedFunction(name, arguments))
+    }
+

--- a/src/main/scala/replcalc/expressions/Function.scala
+++ b/src/main/scala/replcalc/expressions/Function.scala
@@ -1,8 +1,7 @@
 package replcalc.expressions
 
-import replcalc.Preprocessor.ParsedFunction
-import replcalc.{Dictionary, Parser, Preprocessor}
-import replcalc.Preprocessor.LineSide
+import replcalc.{ParsedFunction, Dictionary, Parser, Preprocessor}
+import replcalc.ParsedFunction.LineSide
 import replcalc.expressions.Error.{EvaluationError, ParsingError}
 
 final case class Function(name: String, args: Seq[Expression]) extends Expression:
@@ -16,7 +15,7 @@ final case class Function(name: String, args: Seq[Expression]) extends Expressio
 
 object Function extends Parseable[Function]:
   override def parse(parser: Parser, line: String): ParsedExpr[Function] =
-    Preprocessor.parseFunction(line, LineSide.Right).flatMap {
+    ParsedFunction.parse(line, LineSide.Right).flatMap {
       case Left(error) =>
         ParsedExpr.error(error)
       case Right(ParsedFunction(name, _)) if !parser.dictionary.contains(name) =>

--- a/src/main/scala/replcalc/expressions/FunctionAssignment.scala
+++ b/src/main/scala/replcalc/expressions/FunctionAssignment.scala
@@ -1,8 +1,8 @@
 package replcalc.expressions
 
 import Error.*
-import replcalc.Preprocessor.{ParsedFunction, LineSide}
-import replcalc.{Dictionary, Parser, Preprocessor}
+import replcalc.{ParsedFunction, Dictionary, Parser, Preprocessor}
+import replcalc.ParsedFunction.LineSide
 import scala.util.chaining.*
 
 final case class FunctionAssignment(name: String, argNames: Seq[String], expr: Expression) extends Expression:
@@ -15,7 +15,7 @@ object FunctionAssignment extends Parseable[FunctionAssignment]:
     else
       val assignIndex   = line.indexOf('=')
       val assignmentStr = line.substring(0, assignIndex)
-      Preprocessor.parseFunction(assignmentStr, LineSide.Left).flatMap {
+      ParsedFunction.parse(assignmentStr, LineSide.Left).flatMap {
         case Left(error) =>
           ParsedExpr.error(error)
         case Right(ParsedFunction(name, _)) if parser.dictionary.contains(name) =>

--- a/src/test/scala/replcalc/PreprocessorTest.scala
+++ b/src/test/scala/replcalc/PreprocessorTest.scala
@@ -139,17 +139,17 @@ class PreprocessorTest extends munit.FunSuite:
   }
 
   test("Parse function line") {
-    import Preprocessor.{LineSide, parseFunction, ParsedFunction}
+    import ParsedFunction.{LineSide, parse}
 
-    assertEquals(parseFunction("foo(x)", LineSide.Left), Some(Right(ParsedFunction(name = "foo", arguments = Seq("x")))))
-    assertEquals(parseFunction("foo(x,y)", LineSide.Left), Some(Right(ParsedFunction(name = "foo", arguments = Seq("x", "y")))))
-    assertEquals(parseFunction("foo(1)", LineSide.Right), Some(Right(ParsedFunction(name = "foo", arguments = Seq("1")))))
-    assert(parseFunction("foo(1)", LineSide.Left).exists(_.isLeft)) // error; constants are not allowed on the left side
-    assertEquals(parseFunction("foo()", LineSide.Left), Some(Right(ParsedFunction(name = "foo", arguments = Seq.empty))))
-    assertEquals(parseFunction("foo", LineSide.Right), None) // not a function
-    assertEquals(parseFunction("foo", LineSide.Left), None) // not a function
-    assertEquals(parseFunction("1+2", LineSide.Right), None) // not a function
-    assert(parseFunction("foo(x))", LineSide.Left).exists(_.isLeft)) // error; parentheses don't match
-    assert(parseFunction("foo(x", LineSide.Left).exists(_.isLeft)) // error; parentheses don't match
-    assert(parseFunction("1_2(x)", LineSide.Left).exists(_.isLeft)) // error; invalid name
+    assertEquals(parse("foo(x)", LineSide.Left), Some(Right(ParsedFunction(name = "foo", arguments = Seq("x")))))
+    assertEquals(parse("foo(x,y)", LineSide.Left), Some(Right(ParsedFunction(name = "foo", arguments = Seq("x", "y")))))
+    assertEquals(parse("foo(1)", LineSide.Right), Some(Right(ParsedFunction(name = "foo", arguments = Seq("1")))))
+    assert(parse("foo(1)", LineSide.Left).exists(_.isLeft)) // error; constants are not allowed on the left side
+    assertEquals(parse("foo()", LineSide.Left), Some(Right(ParsedFunction(name = "foo", arguments = Seq.empty))))
+    assertEquals(parse("foo", LineSide.Right), None) // not a function
+    assertEquals(parse("foo", LineSide.Left), None) // not a function
+    assertEquals(parse("1+2", LineSide.Right), None) // not a function
+    assert(parse("foo(x))", LineSide.Left).exists(_.isLeft)) // error; parentheses don't match
+    assert(parse("foo(x", LineSide.Left).exists(_.isLeft)) // error; parentheses don't match
+    assert(parse("1_2(x)", LineSide.Left).exists(_.isLeft)) // error; invalid name
   }


### PR DESCRIPTION
`ParsedFunction` is a small utility class created to help in parsing a function or a function assignment out of a text chunk. If the text is of the form `name(arg1, arg2, ...)`, the parsed function will keep the name and the list of arguments. I will also properly return a `None` if the text doesn't seem to be a function (i.e. it does not have parentheses) and it will return an error if it seems to be a function, but it can't be parsed.