### PR TITLE
fix: An infinite recursion in evaluation when an argument has the same name as a variable

### DIFF
--- a/src/test/scala/replcalc/ExpressionTest.scala
+++ b/src/test/scala/replcalc/ExpressionTest.scala
@@ -207,10 +207,24 @@ class ExpressionTest extends munit.FunSuite:
     eval("x", 1.0)
   }
 
+  test("Call one function from another") {
+    implicit val parser: Parser = Parser() // the same parser will be used in all evaluations
+    parse("foo(x) = x + 1")
+    parse("bar(z) = foo(z) + z")
+    eval("bar(2)", 5.0)
+  }
+
   test("A more complicated example") {
     implicit val parser: Parser = Parser() // the same parser will be used in all evaluations
-    parse("foo(x, y)= x + y")
+    parse("foo(x, y) = x + y")
     parse("bar(z) = foo(z, z)")
     parse("sho(a, b, c) = (foo(a, bar(foo(b, c)) + 3) / 2) * foo(2, a)")
     eval("sho(1, 2, 3)", 21.0)
+  }
+
+  test("Use an argument in a function call with the same name as a previously defined variable") {
+    implicit val parser: Parser = Parser() // the same parser will be used in all evaluations
+    parse("x = 1")
+    parse("f(x) = x + 2")
+    eval("f(x)", 3.0)
   }


### PR DESCRIPTION
If the user first defines a variable, then defines a function with an argument name the same as the variable, and then use the variable in place of the argument to call the function, the program gets confused.

Consider this:
```
x = 1
f(x) = x + 2
f(x)
```

The last line is a call to the function f with the argument being *the variable* `x`, so it should be `f(1)`, and the result should be `3`. The bug was that I first updated the dictionary with the argument `x` associated with `Variable("x")` as its expression, replacing the original variable `x` with the expression `Constant(1.0)`, and only then tried to evaluate the variable x. Now, instead of the constant `1`, the program found in the dictionary the variable `x`, tried to evaluate it, and by evaluating a variable it again looked in the dictionary for `x`, found the variable `x`... and so on.

The fix is to first evaluate arguments to constants, and only then update the dictionary with the arguments.